### PR TITLE
remove opton to download metadata from store listing

### DIFF
--- a/Tasks/app-store-release/app-store-release.js
+++ b/Tasks/app-store-release/app-store-release.js
@@ -32,7 +32,6 @@ var shouldSkipWaitingForProcessing = taskLibrary.getBoolInput("shouldSkipWaiting
 var shouldSubmitForReview = taskLibrary.getBoolInput("shouldSubmitForReview", false);
 var shouldAutoRelease = taskLibrary.getBoolInput("shouldAutoRelease", false);
 var shouldSkipSubmission = taskLibrary.getBoolInput("shouldSkipSubmission", false);
-var shouldInitializeWithAppStoreMetadata = taskLibrary.getBoolInput("shouldInitializeWithAppStoreMetadata", false);
 var teamId = taskLibrary.getInput("teamId", false);
 var teamName = taskLibrary.getInput("teamName", false);
 var bundleIdentifier = taskLibrary.getInput("appIdentifier", true);
@@ -79,7 +78,6 @@ try {
         });
     } else if (releaseTrack === "Production") {
         installRubyGem("deliver").then(function () {
-            var deliverPromise = Q(0);
             // Setting up arguments for initializing deliver command
             // See https://github.com/fastlane/deliver for more information on these arguments
             var deliverArgs = ["--force", "-u", credentials.username, "-a", bundleIdentifier, "-i", ipaPath];
@@ -104,19 +102,7 @@ try {
                 deliverArgs.push("true");
             }
 
-            if (shouldInitializeWithAppStoreMetadata) {
-                deliverPromise = deliverPromise.then(function () {
-                    return runCommand("deliver", ["init", "-u", credentials.username, "-a", bundleIdentifier]);
-                })
-            }
-
-            // First, try to pull screenshots from itunes connect
-            return deliverPromise.then(function () {
-                return runCommand("deliver", deliverArgs).fail(function (err) {
-                    taskLibrary.setResult(1, err.message);
-                    throw err;
-                });
-            });
+            return runCommand("deliver", deliverArgs);
         }).fail(function (err) {
             taskLibrary.setResult(1, err.message);
             throw err;

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": "0",
         "Minor": "0",
-        "Patch": "32"
+        "Patch": "33"
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Publish $(appPath) to the App Store $(releaseTrack)",
@@ -144,15 +144,6 @@
             "required": false,
             "defaultValue": false,
             "helpMarkDown": "Automatically release the app once it is approved.",
-            "visibleRule": "releaseTrack = Production"
-        },
-        {
-            "name": "shouldInitializeWithAppStoreMetadata",
-            "type": "boolean",
-            "label": "Download Metadata from App Store Listing",
-            "required": false,
-            "defaultValue": false,
-            "helpMarkDown": "Download all metadata from iTunes Connect for this app listing before uploading.",
             "visibleRule": "releaseTrack = Production"
         },
         {

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store-vsts-extension",
     "name": "Apple App Store",
-    "version": "0.0.32",
+    "version": "0.0.33",
     "publisher": "ms-vsclient",
     "description": "Provides build/release tasks that enable performing continuous delivery to Apple's App Store from an automated VSTS build or release definition",
     "categories": [


### PR DESCRIPTION
Confirmed with Ruben this option is not useful the way it is. We might want to provide another task to download metadata, so during build users can update it and then publish. But not a requirement for V1.
