### PR TITLE
Disable colored output

### DIFF
--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -61,6 +61,7 @@ async function run() {
         process.env['GEM_HOME'] = gemCache;
         process.env['FASTLANE_PASSWORD'] = credentials.password;
         process.env['FASTLANE_DONT_STORE_PASSWORD'] = true;
+        process.env['FASTLANE_DISABLE_COLORS'] = true;
 
         // Add bin of new gem home so we don't ahve to resolve it later;
         process.env['PATH'] = process.env['PATH'] + ":" + gemCache + path.sep + "bin";


### PR DESCRIPTION
In the [video](https://www.youtube.com/watch?v=g3JwAZYVb58) I saw that the colored output is not properly rendered, so I set the `FASTLANE_DISABLE_COLORS` environment variable to disabled the colored output :+1: