### PR TITLE
Begin using fastlane tools

### DIFF
--- a/Tasks/app-store-promote/Tests/L0.ts
+++ b/Tasks/app-store-promote/Tests/L0.ts
@@ -175,4 +175,21 @@ describe('app-store-promote L0 Suite', function () {
         done();
     });
 
+    it('custom GEM_CACHE environment variable', (done:MochaDone) => {
+        this.timeout(1000);
+
+        //L0GemCacheEnvVar.ts sets the GEM_CACHE env var and expects it to be used when fastlane is updated.
+        let tp = path.join(__dirname, 'L0GemCacheEnvVar.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId -n 42 --skip_binary_upload true --skip_metadata true --skip_screenshots true --force'), 'fastlane deliver with build number should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.ran('/usr/bin/gem update fastlane -i /usr/bin/customGemCache'));
+
+        done();
+    });
+
 });

--- a/Tasks/app-store-promote/Tests/L0.ts
+++ b/Tasks/app-store-promote/Tests/L0.ts
@@ -40,6 +40,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -52,6 +53,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -90,8 +92,8 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --force'), 'deliver with the latest build should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --force'), 'fastlane deliver with the latest build should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -105,8 +107,8 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force'), 'deliver with auto release should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force'), 'fastlane deliver with auto release should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -120,8 +122,8 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId --force'), 'deliver with team id should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId --force'), 'fastlane deliver with team id should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -135,8 +137,8 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -r teamName --force'), 'deliver with team name should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -r teamName --force'), 'fastlane deliver with team name should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -150,8 +152,8 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId -r teamName --force'), 'deliver with team id and team name should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId -r teamName --force'), 'fastlane deliver with team id and team name should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -165,8 +167,8 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver submit_build -u creds-username -a com.microsoft.test.appId -n 42 --skip_binary_upload true --skip_metadata true --skip_screenshots true --force'), 'deliver with build number should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId -n 42 --skip_binary_upload true --skip_metadata true --skip_screenshots true --force'), 'fastlane deliver with build number should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 

--- a/Tasks/app-store-promote/Tests/L0BuildNumber.ts
+++ b/Tasks/app-store-promote/Tests/L0BuildNumber.ts
@@ -20,32 +20,40 @@ tmr.setInput('chooseBuild', 'Specify');
 
 tmr.setInput('buildNumber', '42');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId -n 42 --skip_binary_upload true --skip_metadata true --skip_screenshots true --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId -n 42 --skip_binary_upload true --skip_metadata true --skip_screenshots true --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0GemCacheEnvVar.ts
+++ b/Tasks/app-store-promote/Tests/L0GemCacheEnvVar.ts
@@ -1,0 +1,65 @@
+ /*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'app-store-promote.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('authType', 'UserAndPass');
+tmr.setInput('username', 'creds-username');
+tmr.setInput('password', 'creds-password');
+tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
+tmr.setInput('chooseBuild', 'Specify');
+
+tmr.setInput('buildNumber', '42');
+
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['GEM_CACHE'] = '/usr/bin/customGemCache';
+//process.env['HOME'] = '/usr/bin';
+let gemCache: string = process.env['GEM_CACHE'];
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
+    },
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
+    },
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId -n 42 --skip_binary_upload true --skip_metadata true --skip_screenshots true --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
+        }
+    }
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
+
+// This is how you can mock NPM packages...
+os.platform = () => {
+    return 'darwin';
+};
+tmr.registerMock('os', os);
+
+tmr.run();

--- a/Tasks/app-store-promote/Tests/L0LatestBuild.ts
+++ b/Tasks/app-store-promote/Tests/L0LatestBuild.ts
@@ -19,32 +19,40 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
 tmr.setInput('chooseBuild', 'Latest');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0NoBundleId.ts
+++ b/Tasks/app-store-promote/Tests/L0NoBundleId.ts
@@ -23,23 +23,17 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     'which': {
         'ruby': '/usr/bin/ruby',
         'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+        'deliver': '/usr/bin/deliver'
     },
     'checkPath' : {
         '/usr/bin/ruby': true,
         '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+        '/usr/bin/deliver': true
     },
     'exec': {
         '/usr/bin/gem install deliver': {
             'code': 0,
             'stdout': '1 gem installed'
-        },
-        'deliver submit_build -u creds-username': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
         }
     }
 };

--- a/Tasks/app-store-promote/Tests/L0NoChooseBuild.ts
+++ b/Tasks/app-store-promote/Tests/L0NoChooseBuild.ts
@@ -19,32 +19,40 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
 //tmr.setInput('chooseBuild', 'specify');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0ServiceEndpointDeliver.ts
+++ b/Tasks/app-store-promote/Tests/L0ServiceEndpointDeliver.ts
@@ -21,30 +21,40 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 tmr.setInput('chooseBuild', 'latest');
 tmr.setInput('shouldAutoRelease', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0ShouldAutoRelease.ts
+++ b/Tasks/app-store-promote/Tests/L0ShouldAutoRelease.ts
@@ -20,32 +20,40 @@ tmr.setInput('chooseBuild', 'Latest');
 
 tmr.setInput('shouldAutoRelease', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0TeamId.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamId.ts
@@ -20,32 +20,40 @@ tmr.setInput('chooseBuild', 'Latest');
 
 tmr.setInput('teamId', 'teamId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
@@ -21,32 +21,40 @@ tmr.setInput('chooseBuild', 'Latest');
 tmr.setInput('teamId', 'teamId');
 tmr.setInput('teamName', 'teamName');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId -r teamName --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId -r teamName --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0TeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamName.ts
@@ -20,32 +20,41 @@ tmr.setInput('chooseBuild', 'Latest');
 
 tmr.setInput('teamName', 'teamName');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -r teamName --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -r teamName --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/Tests/L0UserPassDeliver.ts
+++ b/Tasks/app-store-promote/Tests/L0UserPassDeliver.ts
@@ -19,30 +19,40 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 tmr.setInput('chooseBuild', 'latest');
 tmr.setInput('shouldAutoRelease', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-promote/app-store-promote.ts
+++ b/Tasks/app-store-promote/app-store-promote.ts
@@ -52,7 +52,8 @@ async function run() {
         tl.debug('Read all inputs.');
 
         // Set up environment
-        let gemCache: string = path.join(process.env['HOME'], '.gem-cache');
+        tl.debug(`GEM_CACHE=${process.env['GEM_CACHE']}`);
+        let gemCache: string = process.env['GEM_CACHE'] || path.join(process.env['HOME'], '.gem-cache');
         tl.debug(`gemCache=${gemCache}`);
         process.env['GEM_HOME'] = gemCache;
         process.env['FASTLANE_PASSWORD'] = credentials.password;

--- a/Tasks/app-store-promote/app-store-promote.ts
+++ b/Tasks/app-store-promote/app-store-promote.ts
@@ -52,7 +52,8 @@ async function run() {
         tl.debug('Read all inputs.');
 
         // Set up environment
-        let gemCache: string = process.env['GEM_CACHE'] || process.platform === 'win32' ? path.join(process.env['APPDATA'], 'gem-cache') : path.join(process.env['HOME'], '.gem-cache');
+        let gemCache: string = path.join(process.env['HOME'], '.gem-cache');
+        tl.debug(`gemCache=${gemCache}`);
         process.env['GEM_HOME'] = gemCache;
         process.env['FASTLANE_PASSWORD'] = credentials.password;
         process.env['FASTLANE_DONT_STORE_PASSWORD'] = true;
@@ -60,17 +61,22 @@ async function run() {
         // Add bin of new gem home so we don't have to resolve it later
         process.env['PATH'] = process.env['PATH'] + ':' + gemCache + path.sep + 'bin';
 
-        //Install the ruby gem for fastlane deliver
+        // Install the ruby gem for fastlane
         tl.debug('Checking for ruby install...');
         tl.which('ruby', true);
-        let installDeliver: ToolRunner = tl.tool(tl.which('gem', true));
-        installDeliver.arg(['install', 'deliver']);
-        await installDeliver.exec();
+        // Install the fastlane tools (if they're already present, should be a no-op)
+        let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
+        gemRunner.arg(['install', 'fastlane']);
+        await gemRunner.exec();
+        // Always update fastlane (if already latest, should be a no-op)
+        gemRunner = tl.tool(tl.which('gem', true));
+        gemRunner.arg(['update', 'fastlane', '-i', gemCache]);
+        await gemRunner.exec();
 
         //Run the deliver command 
         // See https://github.com/fastlane/deliver for more information on these arguments
-        let deliverCommand: ToolRunner = tl.tool('deliver');
-        deliverCommand.arg(['submit_build', '-u', credentials.username, '-a', appIdentifier]);
+        let deliverCommand: ToolRunner = tl.tool('fastlane');
+        deliverCommand.arg(['deliver', 'submit_build', '-u', credentials.username, '-a', appIdentifier]);
         if (chooseBuild.toLowerCase() === 'specify') {
            deliverCommand.arg(['-n', buildNumber]);
         }

--- a/Tasks/app-store-promote/package.json
+++ b/Tasks/app-store-promote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-promote",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "VSTS task to promote a build in the Apple App Store",
   "main": "app-store-promote.js",
   "dependencies": {

--- a/Tasks/app-store-promote/package.json
+++ b/Tasks/app-store-promote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-promote",
-  "version": "1.3.0",
+  "version": "1.112.0",
   "description": "VSTS task to promote a build in the Apple App Store",
   "main": "app-store-promote.js",
   "dependencies": {

--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,8 +13,8 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "2",
-        "Patch": "1"
+        "Minor": "3",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Submit to the App Store for review",

--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "112",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "3",
+    "Minor": "112",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,8 +15,8 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "2",
-    "Patch": "1"
+    "Minor": "3",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/app-store-release/Tests/L0.ts
+++ b/Tasks/app-store-release/Tests/L0.ts
@@ -73,6 +73,21 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
+    it('custom GEM_CACHE env var', (done:MochaDone) => {
+        this.timeout(1000);
+
+        //L0GemCacheEnvVar.ts sets the GEM_CACHE env var and expects it to be used when fastlane is updated.
+        let tp = path.join(__dirname, 'L0GemCacheEnvVar.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.ran('/usr/bin/gem update fastlane -i /usr/bin/customGemCache'));
+
+        done();
+    });
+
     it('testflight - username+password', (done:MochaDone) => {
         this.timeout(1000);
 

--- a/Tasks/app-store-release/Tests/L0.ts
+++ b/Tasks/app-store-release/Tests/L0.ts
@@ -80,6 +80,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -92,6 +93,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -117,8 +119,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('pilot upload -u creds-username -i mypackage.ipa -q teamId'), 'pilot upload with teamId should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and pilot.');
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId'), 'fastlane pilot upload with teamId should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -132,8 +134,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('pilot upload -u creds-username -i mypackage.ipa -r teamName'), 'pilot upload with teamName should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and pilot.');
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -r teamName'), 'fastlane pilot upload with teamName should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -147,8 +149,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('pilot upload -u creds-username -i mypackage.ipa -q teamId -r teamName'), 'pilot upload with teamId and teamName should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and pilot.');
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -r teamName'), 'fastlane pilot upload with teamId and teamName should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -162,8 +164,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('pilot upload -u creds-username -i mypackage.ipa --skip_submission true'), 'pilot upload with skip_submission should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and pilot.');
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa --skip_submission true'), 'fastlane pilot upload with skip_submission should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -177,8 +179,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('pilot upload -u creds-username -i mypackage.ipa --skip_waiting_for_build_processing true'), 'pilot upload with skip_waiting_for_build_processing should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and pilot.');
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa --skip_waiting_for_build_processing true'), 'fastlane pilot upload with skip_waiting_for_build_processing should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -192,6 +194,9 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa'), 'fastlane pilot upload with one ip file should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -232,6 +237,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.invokedToolCount === 2, 'should have run gem install and gem update.');
         assert(tr.stdout.indexOf('Input required: appIdentifier') !== -1, 'Task should have written to stdout');
         assert(tr.failed, 'task should have failed');
 
@@ -245,6 +251,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.invokedToolCount === 0, 'should not have any tools since ipaPath was not provided.');
         assert(tr.stdout.indexOf('Input required: ipaPath') !== -1, 'Task should have written to stdout');
         assert(tr.failed, 'task should have failed');
 
@@ -258,8 +265,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_binary_upload true --skip_metadata true --skip_screenshots true'), 'deliver with skip_binary_upload should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_binary_upload true --skip_metadata true --skip_screenshots true'), 'fastlane deliver with skip_binary_upload should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -273,8 +280,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId'), 'deliver with teamId should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId'), 'fastlane deliver with teamId should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -288,8 +295,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -r teamName'), 'deliver with teamName should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -r teamName'), 'fastlane deliver with teamName should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -303,8 +310,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId -r teamName'), 'deliver with teamId and teamName should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId -r teamName'), 'fastlane deliver with teamId and teamName should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -318,8 +325,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --submit_for_review true'), 'deliver with submit_for_review should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --submit_for_review true'), 'fastlane deliver with submit_for_review should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -333,8 +340,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --automatic_release true'), 'deliver with automatic_release should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --automatic_release true'), 'fastlane deliver with automatic_release should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -348,8 +355,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -m <path> --skip_screenshots true'), 'deliver with -m should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -m <path> --skip_screenshots true'), 'fastlane deliver with -m should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -363,8 +370,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true -w <path>'), 'deliver with -w should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run both gem and deliver.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true -w <path>'), 'fastlane deliver with -w should have been run.');
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -378,6 +385,8 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();

--- a/Tasks/app-store-release/Tests/L0GemCacheEnvVar.ts
+++ b/Tasks/app-store-release/Tests/L0GemCacheEnvVar.ts
@@ -1,0 +1,68 @@
+ /*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'app-store-release.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('authType', 'UserAndPass');
+tmr.setInput('username', 'creds-username');
+tmr.setInput('password', 'creds-password');
+tmr.setInput('releaseTrack', 'TestFlight');
+tmr.setInput('ipaPath', 'mypackage.ipa');
+
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+//process.env['HOME'] = '/usr/bin';
+process.env['GEM_CACHE'] = '/usr/bin/customGemCache';
+let gemCache: string = process.env['GEM_CACHE'];
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
+    },
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
+    },
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
+        ]
+    },
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
+        }
+    }
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
+
+// This is how you can mock NPM packages...
+os.platform = () => {
+    return 'darwin';
+};
+tmr.registerMock('os', os);
+
+tmr.run();

--- a/Tasks/app-store-release/Tests/L0ProductionMultipleIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionMultipleIpaFiles.ts
@@ -19,34 +19,31 @@ tmr.setInput('releaseTrack', 'Production');
 tmr.setInput('ipaPath', '**/*.ipa');
 tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        '**/*.ipa': [
-            'files/first.ipa',
-            'files/second.ipa'
+    "glob": {
+        "**/*.ipa": [
+            "files/first.ipa",
+            "files/second.ipa"
         ]
-    },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
-        }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionNoBundleId.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionNoBundleId.ts
@@ -16,32 +16,45 @@ tmr.setInput('authType', 'UserAndPass');
 tmr.setInput('username', 'creds-username');
 tmr.setInput('password', 'creds-password');
 tmr.setInput('releaseTrack', 'Production');
-tmr.setInput('ipaPath', '<path>');
+tmr.setInput('ipaPath', 'mypackage.ipa');
 
 //tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
+        ]
+    },
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionNoIpaPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionNoIpaPath.ts
@@ -20,24 +20,27 @@ tmr.setInput('password', 'creds-password');
 tmr.setInput('releaseTrack', 'Production');
 
 // let ipaPath: string = tl.getInput('ipaPath', true);
-//tmr.setInput('ipaPath', '<path>');
+//tmr.setInput('ipaPath', 'mypackage.ipa');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionOneIpaFile.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionOneIpaFile.ts
@@ -20,37 +20,45 @@ tmr.setInput('releaseTrack', 'Production');
 
 tmr.setInput('ipaPath', '**/*.ipa');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        '**/*.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "**/*.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionShouldAutoRelease.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldAutoRelease.ts
@@ -21,37 +21,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
 tmr.setInput('shouldAutoRelease', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --automatic_release true': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --automatic_release true": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionShouldSkipBinaryUpload.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldSkipBinaryUpload.ts
@@ -21,37 +21,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
 tmr.setInput('skipBinaryUpload', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_binary_upload true --skip_metadata true --skip_screenshots true': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_binary_upload true --skip_metadata true --skip_screenshots true": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionShouldSubmitForReview.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldSubmitForReview.ts
@@ -21,37 +21,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
 tmr.setInput('shouldSubmitForReview', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --submit_for_review true': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true --submit_for_review true": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
@@ -21,37 +21,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
 tmr.setInput('teamId', 'teamId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
@@ -22,37 +22,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 tmr.setInput('teamId', 'teamId');
 tmr.setInput('teamName', 'teamName');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId -r teamName': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId -r teamName": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
@@ -21,37 +21,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
 tmr.setInput('teamName', 'teamName');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -r teamName': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -r teamName": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionUploadMetadataMetadataPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionUploadMetadataMetadataPath.ts
@@ -22,37 +22,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 tmr.setInput('uploadMetadata', 'true');
 tmr.setInput('metadataPath', '<path>');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -m <path> --skip_screenshots true': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -m <path> --skip_screenshots true": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
@@ -22,37 +22,45 @@ tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 tmr.setInput('uploadScreenshots', 'true');
 tmr.setInput('screenshotsPath', '<path>');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true -w <path>': {
-            'code': 0,
-            'stdout': 'consider it delivered!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true -w <path>": {
+            "code": 0,
+            "stdout": "consider it delivered!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0ProductionZeroIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionZeroIpaFiles.ts
@@ -19,32 +19,29 @@ tmr.setInput('releaseTrack', 'Production');
 tmr.setInput('ipaPath', '**/*.ipa');
 tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        '**/*.ipa': [
+    "glob": {
+        "**/*.ipa": [
         ]
-    },
-    'exec': {
-        '/usr/bin/gem install deliver': {
-            'code': 0,
-            'stdout': '1 gem installed'
-        }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightMultipleIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightMultipleIpaFiles.ts
@@ -19,34 +19,42 @@ tmr.setInput('releaseTrack', 'TestFlight');
 tmr.setInput('ipaPath', '**/*.ipa');
 tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        '**/*.ipa': [
-            'files/first.ipa',
-            'files/second.ipa'
+    "glob": {
+        "**/*.ipa": [
+            "files/first.ipa",
+            "files/second.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightOneIpaFile.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightOneIpaFile.ts
@@ -20,37 +20,45 @@ tmr.setInput('releaseTrack', 'TestFlight');
 // let ipaPath: string = tl.getInput('ipaPath', true);
 tmr.setInput('ipaPath', '**/*.ipa');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        '**/*.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "**/*.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightServiceEndpoint.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightServiceEndpoint.ts
@@ -21,37 +21,45 @@ tmr.setInput('releaseTrack', 'TestFlight');
 
 tmr.setInput('ipaPath', 'mypackage.ipa');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightShouldSkipSubmission.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightShouldSkipSubmission.ts
@@ -20,37 +20,45 @@ tmr.setInput('ipaPath', 'mypackage.ipa');
 
 tmr.setInput('shouldSkipSubmission', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa --skip_submission true': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa --skip_submission true": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
@@ -20,37 +20,45 @@ tmr.setInput('ipaPath', 'mypackage.ipa');
 
 tmr.setInput('shouldSkipWaitingForProcessing', 'true');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa --skip_waiting_for_build_processing true': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa --skip_waiting_for_build_processing true": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
@@ -21,37 +21,45 @@ tmr.setInput('ipaPath', 'mypackage.ipa');
 
 tmr.setInput('teamId', 'teamId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa -q teamId': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamIdTeamName.ts
@@ -21,37 +21,45 @@ tmr.setInput('ipaPath', 'mypackage.ipa');
 tmr.setInput('teamId', 'teamId');
 tmr.setInput('teamName', 'teamName');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa -q teamId -r teamName': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -r teamName": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamName.ts
@@ -20,37 +20,45 @@ tmr.setInput('ipaPath', 'mypackage.ipa');
 
 tmr.setInput('teamName', 'teamName');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa -r teamName': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -r teamName": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightUserPass.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightUserPass.ts
@@ -18,37 +18,45 @@ tmr.setInput('password', 'creds-password');
 tmr.setInput('releaseTrack', 'TestFlight');
 tmr.setInput('ipaPath', 'mypackage.ipa');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        'mypackage.ipa': [
-            'mypackage.ipa'
+    "glob": {
+        "mypackage.ipa": [
+            "mypackage.ipa"
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
         },
-        'pilot upload -u creds-username -i mypackage.ipa': {
-            'code': 0,
-            'stdout': 'consider it uploaded!'
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+            "code": 0,
+            "stdout": "consider it uploaded!"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/Tests/L0TestFlightZeroIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightZeroIpaFiles.ts
@@ -19,32 +19,40 @@ tmr.setInput('releaseTrack', 'TestFlight');
 tmr.setInput('ipaPath', '**/*.ipa');
 tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 
-// provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
-    'which': {
-        'ruby': '/usr/bin/ruby',
-        'gem': '/usr/bin/gem',
-        'deliver': '/usr/bin/deliver',
-        'pilot': '/usr/bin/pilot'
+process.env['MOCK_NORMALIZE_SLASHES'] = true;
+process.env['HOME'] = '/usr/bin';
+let gemCache: string = '/usr/bin/.gem-cache';
+
+//construct a string that is JSON, call JSON.parse(string), send that to ma.TaskLibAnswers
+let myAnswers: string = `{
+    "which": {
+        "ruby": "/usr/bin/ruby",
+        "gem": "/usr/bin/gem",
+        "fastlane": "/usr/bin/fastlane"
     },
-    'checkPath' : {
-        '/usr/bin/ruby': true,
-        '/usr/bin/gem': true,
-        '/usr/bin/deliver': true,
-        '/usr/bin/pilot': true
+    "checkPath" : {
+        "/usr/bin/ruby": true,
+        "/usr/bin/gem": true,
+        "/usr/bin/fastlane": true
     },
-    'glob': {
-        '**/*.ipa': [
+    "glob": {
+        "**/*.ipa": [
         ]
     },
-    'exec': {
-        '/usr/bin/gem install pilot': {
-            'code': 0,
-            'stdout': '10 gems installed'
+    "exec": {
+        "/usr/bin/gem install fastlane": {
+            "code": 0,
+            "stdout": "1 gem installed"
+        },
+        "/usr/bin/gem update fastlane -i ${gemCache}": {
+            "code": 0,
+            "stdout": "1 gem installed"
         }
     }
-};
-tmr.setAnswers(a);
+ }`;
+let json: any = JSON.parse(myAnswers);
+// Cast the json blob into a TaskLibAnswers
+tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -78,7 +78,8 @@ async function run() {
         let teamName: string = tl.getInput('teamName', false);
 
         // Set up environment
-        let gemCache: string = process.env['GEM_CACHE'] || process.platform === 'win32' ? path.join(process.env['APPDATA'], 'gem-cache') : path.join(process.env['HOME'], '.gem-cache');
+        let gemCache: string = path.join(process.env['HOME'], '.gem-cache');
+        tl.debug(`gemCache=${gemCache}`);
         process.env['GEM_HOME'] = gemCache;
         process.env['FASTLANE_PASSWORD'] = credentials.password;
         process.env['FASTLANE_DONT_STORE_PASSWORD'] = true;
@@ -87,20 +88,26 @@ async function run() {
         // Add bin of new gem home so we don't have to resolve it later
         process.env['PATH'] = process.env['PATH'] + ':' + gemCache + path.sep + 'bin';
 
+        // Ensure there's exactly one ipa before installing fastlane tools
+        ipaPath = findIpa(ipaPath);
+
+        // Install the ruby gem for fastlane
+        tl.debug('Checking for ruby install...');
+        tl.which('ruby', true);
+        // Install the fastlane tools (if they're already present, should be a no-op)
+        let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
+        gemRunner.arg(['install', 'fastlane']);
+        await gemRunner.exec();
+        // Always update fastlane (if already latest, should be a no-op)
+        gemRunner = tl.tool(tl.which('gem', true));
+        gemRunner.arg(['update', 'fastlane', '-i', gemCache]);
+        await gemRunner.exec();
+
+        //gem update fastlane -i ~/.gem-cache
         if (releaseTrack === 'TestFlight') {
-            // Determine which ipa package to pass to pilot
-            ipaPath = findIpa(ipaPath);
-
-            // Install the ruby gem for fastlane pilot
-            tl.debug('Checking for ruby install...');
-            tl.which('ruby', true);
-            let installPilot: ToolRunner = tl.tool(tl.which('gem', true));
-            installPilot.arg(['install', 'pilot']);
-            await installPilot.exec();
-
-            // Run pilot to upload to testflight
-            let pilotCommand: ToolRunner = tl.tool('pilot');
-            pilotCommand.arg(['upload', '-u', credentials.username, '-i', ipaPath]);
+            // Run pilot (via fastlane) to upload to testflight
+            let pilotCommand: ToolRunner = tl.tool('fastlane');
+            pilotCommand.arg(['pilot', 'upload', '-u', credentials.username, '-i', ipaPath]);
             if (isValidFilePath(releaseNotes)) {
                 pilotCommand.arg(['--changelog', fs.readFileSync(releaseNotes).toString()]);
             }
@@ -111,20 +118,10 @@ async function run() {
             await pilotCommand.exec();
         } else if (releaseTrack === 'Production') {
             let bundleIdentifier: string = tl.getInput('appIdentifier', true);
-            // Determine which ipa package to pass to deliver
-            ipaPath = findIpa(ipaPath);
-
-            //Install the ruby gem for fastlane deliver
-            tl.debug('Checking for ruby install...');
-            tl.which('ruby', true);
-            let installDeliver: ToolRunner = tl.tool(tl.which('gem', true));
-            installDeliver.arg(['install', 'deliver']);
-            await installDeliver.exec();
-
-            // Run deliver to publish to Production track
+            // Run deliver (via fastlane) to publish to Production track
             // See https://github.com/fastlane/deliver for more information on these arguments
-            let deliverCommand : ToolRunner = tl.tool('deliver');
-            deliverCommand.arg(['--force', '-u', credentials.username, '-a', bundleIdentifier, '-i', ipaPath]);
+            let deliverCommand: ToolRunner = tl.tool('fastlane');
+            deliverCommand.arg(['deliver', '--force', '-u', credentials.username, '-a', bundleIdentifier, '-i', ipaPath]);
             deliverCommand.argIf(skipBinaryUpload, ['--skip_binary_upload', 'true']);
             // upload metadata if specified
             if (uploadMetadata && metadataPath) {

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -78,7 +78,8 @@ async function run() {
         let teamName: string = tl.getInput('teamName', false);
 
         // Set up environment
-        let gemCache: string = path.join(process.env['HOME'], '.gem-cache');
+        tl.debug(`GEM_CACHE=${process.env['GEM_CACHE']}`);
+        let gemCache: string = process.env['GEM_CACHE'] || path.join(process.env['HOME'], '.gem-cache');
         tl.debug(`gemCache=${gemCache}`);
         process.env['GEM_HOME'] = gemCache;
         process.env['FASTLANE_PASSWORD'] = credentials.password;

--- a/Tasks/app-store-release/package.json
+++ b/Tasks/app-store-release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-release",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "VSTS task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {

--- a/Tasks/app-store-release/package.json
+++ b/Tasks/app-store-release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-release",
-  "version": "1.3.0",
+  "version": "1.112.0",
   "description": "VSTS task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,8 +13,8 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "2",
-        "Patch": "1"
+        "Minor": "3",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "112",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "3",
+    "Minor": "112",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -15,8 +15,8 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "2",
-    "Patch": "1"
+    "Minor": "3",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/ipa-resign/ipa-resign.ts
+++ b/Tasks/ipa-resign/ipa-resign.ts
@@ -139,16 +139,22 @@ async function run() {
         // Add bin of new gem home so we don't ahve to resolve it later;
         process.env['PATH'] = process.env['PATH'] + ':' + gemCache + path.sep + 'bin';
 
-        // Install the ruby gem for fastlane sigh
+        // Install the ruby gem for fastlane
         tl.debug('Checking for ruby install...');
         tl.which('ruby', true);
-        let installSigh: ToolRunner = tl.tool(tl.which('gem', true));
-        installSigh.arg(['install', 'sigh']);
-        await installSigh.exec();
+        // Install the fastlane tools (if they're already present, should be a no-op)
+        let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
+        gemRunner.arg(['install', 'fastlane']);
+        await gemRunner.exec();
+        // Always update fastlane (if already latest, should be a no-op)
+        gemRunner = tl.tool(tl.which('gem', true));
+        gemRunner.arg(['update', 'fastlane', '-i', gemCache]);
+        await gemRunner.exec();
 
         // Run the sigh command 
         // See https://github.com/fastlane/fastlane/tree/master/sigh for more information on these arguments
-        let sighCommand: ToolRunner = tl.tool('sigh');
+        let sighCommand: ToolRunner = tl.tool('fastlane');
+        sighCommand.arg(['sigh']);
         sighCommand.arg(['resign', useIpaPath]);
         sighCommand.arg(['--keychain_path', useKeychain]);
         sighCommand.arg(['--signing_identity', useSigningIdentity]);

--- a/Tasks/ipa-resign/ipa-resign.ts
+++ b/Tasks/ipa-resign/ipa-resign.ts
@@ -132,8 +132,9 @@ async function run() {
 
         // Having all the params ready configure the environment and exec fastlane sigh resign.
         // Set up environment
-        let gemCache: string = process.env['GEM_CACHE'] || process.platform === 'win32' ? path.join(process.env['APPDATA'], 'gem-cache') : path.join(process.env['HOME'], '.gem-cache');
-        process.env['GEM_HOME'] = gemCache;
+        tl.debug(`GEM_CACHE=${process.env['GEM_CACHE']}`);
+        let gemCache: string = process.env['GEM_CACHE'] || path.join(process.env['HOME'], '.gem-cache');
+        tl.debug(`gemCache=${gemCache}`);
         process.env['FASTLANE_DISABLE_COLORS'] = true;
 
         // Add bin of new gem home so we don't ahve to resolve it later;

--- a/Tasks/ipa-resign/package.json
+++ b/Tasks/ipa-resign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipa-resign",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "VSTS task to resign an ipa file",
   "main": "ipa-resign.js",
   "dependencies": {

--- a/Tasks/ipa-resign/package.json
+++ b/Tasks/ipa-resign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipa-resign",
-  "version": "1.3.0",
+  "version": "1.112.0",
   "description": "VSTS task to resign an ipa file",
   "main": "ipa-resign.js",
   "dependencies": {

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "112",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -12,8 +12,8 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "2",
-        "Patch": "1"
+        "Minor": "3",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Resign ipa file",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "3",
+    "Minor": "112",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -14,8 +14,8 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "2",
-    "Patch": "1"
+    "Minor": "3",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Team Services build or release definition",
     "categories": [

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.3.0",
+    "version": "1.112.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Team Services build or release definition",
     "categories": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A set of TFS/Team Services tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR addresses #54 and #44 (basically, issues where the latest tools were not installed).  With this change, we're moving to use the fastlane tools directly (instead of pilot and deliver).  As of 2.0, calling pilot and deliver (and the other fastlane tools) directly is deprecated.  Also, we don't want to delete the gem cache completely since we may not have installed all of the gems that are present.

The main changes are in app-store-promote/app-store-promote.ts, app-store-release/app-store-release.ts, and ipa-resign/ipa-resign.ts.

**AppStorePromote**
- Install, update and use the fastlane tools (instead of pilot and deliver directly).  At this point, we will always update the fastlane tools.
- Simplify setting the gemCache since the task only runs on darwin (this makes setting the gemCache in unit test mocks possible)
- Update tests to support calling fastlane tools

**AppStoreRelease**
- Install, update and use the fastlane tools (instead of pilot and deliver directly).  At this point, we will always update the fastlane tools.
- Simplify setting the gemCache since the task only runs on darwin (this makes setting the gemCache in unit test mocks possible)
- Move finding the ipa file before installing/updating the fastlane tools (to potentially save some time).
- Update tests to support calling fastlane tools

**IpaResign:**
- Install, update and use the fastlane tools (instead of pilot and deliver directly).  At this point, we will always update the fastlane tools.

