### PR TITLE
Uninstall fastlane for specific version install, fix deliver args

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Allows you to promote an app previously updated to iTunes Connect to the App Sto
 
 4. **fastlane Version** - **Latest Version** or **Specific Version**.  If *Specific Version* is chosen, you must provide a value for *fastlane Specific Version*.
 
-5. **fastlane Specific Version** *(String)* - The version of fastlane to install (e.g., 2.15.1).
+5. **fastlane Specific Version** *(String)* - The version of fastlane to install (e.g., 2.15.1).  If a specific version of fastlane is installed, all previously installed versions will be uninstalled beforehand.
 
 ## Firewall Issues
 

--- a/Tasks/app-store-promote/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/app-store-promote/Strings/resources.resjson/en-US/resources.resjson
@@ -27,7 +27,7 @@
   "loc.input.label.fastlaneToolsVersion": "fastlane Version",
   "loc.input.help.fastlaneToolsVersion": "Choose to install either the lastest version of fastlane or a specific version.",
   "loc.input.label.fastlaneToolsSpecificVersion": "fastlane Specific Version",
-  "loc.input.help.fastlaneToolsSpecificVersion": "Provide the version of fastlane to install (e.g., 2.15.1).",
+  "loc.input.help.fastlaneToolsSpecificVersion": "Provide the version of fastlane to install (e.g., 2.15.1).  If a specific version of fastlane is installed, all previously installed versions will be uninstalled beforehand.",
   "loc.messages.DarwinOnly": "The Apple App Store Promote task can only run on a Mac computer.",
   "loc.messages.SuccessfullySubmitted": "Build successfully submitted for review."
 }

--- a/Tasks/app-store-promote/Tests/L0.ts
+++ b/Tasks/app-store-promote/Tests/L0.ts
@@ -53,7 +53,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.invokedToolCount === 1, 'should have only run fastlane pilot.');
+        assert(tr.invokedToolCount === 1, 'should have only run fastlane deliver.');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -66,8 +66,9 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.ran('/usr/bin/gem uninstall fastlane -a -I'), 'gem uninstall fastlane should have been run.');
         assert(tr.ran('/usr/bin/gem install fastlane -v 2.15.1'), 'gem install fastlane with a specific version should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run only gem install and fastlane pilot.');
+        assert(tr.invokedToolCount === 3, 'should have run gem uninstall, gem install and fastlane deliver.');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -162,7 +163,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId --force'), 'fastlane deliver with team id should have been run.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId --force'), 'fastlane deliver with team id should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -177,7 +178,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -r teamName --force'), 'fastlane deliver with team name should have been run.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -e teamName --force'), 'fastlane deliver with team name should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -192,7 +193,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId -r teamName --force'), 'fastlane deliver with team id and team name should have been run.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId -e teamName --force'), 'fastlane deliver with team id and team name should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/app-store-promote/Tests/L0SpecificFastlaneInstall.ts
+++ b/Tasks/app-store-promote/Tests/L0SpecificFastlaneInstall.ts
@@ -38,6 +38,10 @@ let myAnswers: string = `{
         "/usr/bin/fastlane": true
     },
     "exec": {
+        "/usr/bin/gem uninstall fastlane -a -I": {
+            "code": 0,
+            "stdout": "Successfully uninstalled fastlane-2.15.1"
+        },
         "/usr/bin/gem install fastlane -v 2.15.1": {
             "code": 0,
             "stdout": "1 gem installed"

--- a/Tasks/app-store-promote/Tests/L0TeamId.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamId.ts
@@ -47,7 +47,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId --force": {
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId --force": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
@@ -48,7 +48,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -q teamId -r teamName --force": {
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId -e teamName --force": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-promote/Tests/L0TeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamName.ts
@@ -47,7 +47,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -r teamName --force": {
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -e teamName --force": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-promote/app-store-promote.ts
+++ b/Tasks/app-store-promote/app-store-promote.ts
@@ -72,6 +72,15 @@ async function run() {
         tl.debug('Checking for ruby install...');
         tl.which('ruby', true);
 
+        //Whenever a specific version of fastlane is requested, we're going to uninstall all installed
+        //versions of fastlane beforehand.  Note that this doesn't uninstall dependencies of fastlane.
+        if (installFastlane && fastlaneVersionToInstall) {
+            let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
+            gemRunner.arg(['uninstall', 'fastlane']);
+            tl.debug(`Uninstalling all fastlane versions...`);
+            gemRunner.arg(['-a', '-I']);  //uninstall all versions
+            await gemRunner.exec();
+        }
         // If desired, install the fastlane tools (if they're already present, should be a no-op)
         if (installFastlane) {
             tl.debug('Installing fastlane...');
@@ -95,7 +104,7 @@ async function run() {
         }
 
         //Run the deliver command 
-        // See https://github.com/fastlane/deliver for more information on these arguments
+        // See https://github.com/fastlane/fastlane/blob/master/deliver/lib/deliver/options.rb for more information on these arguments
         let deliverCommand: ToolRunner = tl.tool('fastlane');
         deliverCommand.arg(['deliver', 'submit_build', '-u', credentials.username, '-a', appIdentifier]);
         if (chooseBuild.toLowerCase() === 'specify') {
@@ -103,8 +112,8 @@ async function run() {
         }
         deliverCommand.arg(['--skip_binary_upload', 'true', '--skip_metadata', 'true', '--skip_screenshots', 'true']);
         deliverCommand.argIf(shouldAutoRelease, '--automatic_release');
-        deliverCommand.argIf(teamId, ['-q', teamId]);
-        deliverCommand.argIf(teamName, ['-r', teamName]);
+        deliverCommand.argIf(teamId, ['-k', teamId]);
+        deliverCommand.argIf(teamName, ['-e', teamName]);
         deliverCommand.arg('--force');
 
         await deliverCommand.exec();

--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -149,7 +149,7 @@
             "defaultValue": "",
             "required": true,
             "groupName": "advanced",
-            "helpMarkDown": "Provide the version of fastlane to install (e.g., 2.15.1).",
+            "helpMarkDown": "Provide the version of fastlane to install (e.g., 2.15.1).  If a specific version of fastlane is installed, all previously installed versions will be uninstalled beforehand.",
             "visibleRule": "fastlaneToolsVersion = SpecificVersion"
         }
     ],

--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "114",
+        "Minor": "115",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "114",
+    "Minor": "115",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
@@ -46,7 +46,7 @@
   "loc.input.label.fastlaneToolsVersion": "fastlane Version",
   "loc.input.help.fastlaneToolsVersion": "Choose to install either the lastest version of fastlane or a specific version.",
   "loc.input.label.fastlaneToolsSpecificVersion": "fastlane Specific Version",
-  "loc.input.help.fastlaneToolsSpecificVersion": "Provide the version of fastlane to install (e.g., 2.15.1).",
+  "loc.input.help.fastlaneToolsSpecificVersion": "Provide the version of fastlane to install (e.g., 2.15.1).  If a specific version of fastlane is installed, all previously installed versions will be uninstalled beforehand.",
   "loc.messages.DarwinOnly": "The Apple App Store Release task can only run on a Mac computer.",
   "loc.messages.SuccessfullyPublished": "Successfully published to %s",
   "loc.messages.NoIpaFilesFound": "No IPA file found using pattern: %s",

--- a/Tasks/app-store-release/Tests/L0.ts
+++ b/Tasks/app-store-release/Tests/L0.ts
@@ -121,8 +121,9 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        assert(tr.ran('/usr/bin/gem uninstall fastlane -a -I'), 'gem uninstall fastlane should have been run.');
         assert(tr.ran('/usr/bin/gem install fastlane -v 2.15.1'), 'gem install fastlane with a specific version should have been run.');
-        assert(tr.invokedToolCount === 2, 'should have run only gem install and fastlane pilot.');
+        assert(tr.invokedToolCount === 3, 'should have run gem uninstall, gem install and fastlane pilot.');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();
@@ -335,7 +336,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId'), 'fastlane deliver with teamId should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -k teamId'), 'fastlane deliver with teamId should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -350,7 +351,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -r teamName'), 'fastlane deliver with teamName should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -e teamName'), 'fastlane deliver with teamName should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -365,7 +366,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId -r teamName'), 'fastlane deliver with teamId and teamName should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -k teamId -e teamName'), 'fastlane deliver with teamId and teamName should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -k teamId": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -q teamId -r teamName": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -k teamId -e teamName": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -r teamName": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa --skip_metadata true --skip_screenshots true -e teamName": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstall.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstall.ts
@@ -42,6 +42,10 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
+        "/usr/bin/gem uninstall fastlane -a -I": {
+            "code": 0,
+            "stdout": "Successfully uninstalled fastlane-2.15.1"
+        },
         "/usr/bin/gem install fastlane -v 2.15.1": {
             "code": 0,
             "stdout": "1 gem installed"

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "114",
+        "Minor": "115",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -243,7 +243,7 @@
             "defaultValue": "",
             "required": true,
             "groupName": "advanced",
-            "helpMarkDown": "Provide the version of fastlane to install (e.g., 2.15.1).",
+            "helpMarkDown": "Provide the version of fastlane to install (e.g., 2.15.1).  If a specific version of fastlane is installed, all previously installed versions will be uninstalled beforehand.",
             "visibleRule": "fastlaneToolsVersion = SpecificVersion"
         }
     ],

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "114",
+    "Minor": "115",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ipa-resign/Strings/resources.resjson/en-US/resources.resjson
@@ -38,7 +38,7 @@
   "loc.input.label.fastlaneToolsVersion": "fastlane Version",
   "loc.input.help.fastlaneToolsVersion": "Choose to install either the lastest version of fastlane or a specific version.",
   "loc.input.label.fastlaneToolsSpecificVersion": "fastlane Specific Version",
-  "loc.input.help.fastlaneToolsSpecificVersion": "Provide the version of fastlane to install (e.g., 2.15.1).",
+  "loc.input.help.fastlaneToolsSpecificVersion": "Provide the version of fastlane to install (e.g., 2.15.1).  If a specific version of fastlane is installed, all previously installed versions will be uninstalled beforehand.",
   "loc.messages.DarwinOnly": "The Ipa Resign task can only run on a Mac computer.",
   "loc.messages.SuccessfullyResigned": "Successfully resigned ipa %s",
   "loc.messages.FailedTemporaryKeyDeletion": "Failed to delete temporary keychain created during the resign process. %s",

--- a/Tasks/ipa-resign/ipa-resign.ts
+++ b/Tasks/ipa-resign/ipa-resign.ts
@@ -151,6 +151,15 @@ async function run() {
         tl.debug('Checking for ruby install...');
         tl.which('ruby', true);
 
+        //Whenever a specific version of fastlane is requested, we're going to uninstall all installed
+        //versions of fastlane beforehand.  Note that this doesn't uninstall dependencies of fastlane.
+        if (installFastlane && fastlaneVersionToInstall) {
+            let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
+            gemRunner.arg(['uninstall', 'fastlane']);
+            tl.debug(`Uninstalling all fastlane versions...`);
+            gemRunner.arg(['-a', '-I']);  //uninstall all versions
+            await gemRunner.exec();
+        }
         // If desired, install the fastlane tools (if they're already present, should be a no-op)
         if (installFastlane) {
             tl.debug('Installing fastlane...');

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -197,7 +197,7 @@
             "defaultValue": "",
             "required": true,
             "groupName": "advanced",
-            "helpMarkDown": "Provide the version of fastlane to install (e.g., 2.15.1).",
+            "helpMarkDown": "Provide the version of fastlane to install (e.g., 2.15.1).  If a specific version of fastlane is installed, all previously installed versions will be uninstalled beforehand.",
             "visibleRule": "fastlaneToolsVersion = SpecificVersion"
         }
     ],

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "114",
+        "Minor": "115",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "114",
+    "Minor": "115",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.114.0",
+    "version": "1.115.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Team Services build or release definition",
     "categories": [


### PR DESCRIPTION
When installing a specific version of fastlane, uninstall all previous versions of fastlane.  This will allow a rollback to a prior version (currently, if a prior version is installed without installing, the later version still is used).  This _won't_ uninstall any fastlane dependencies.  If there are bugs in fastlane dependencies, those will have to be managed on the build machine directly.  This will close #60.

Also, set the proper args for TeamId and TeamName when we call deliver.  This will close #62.