### PR TITLE
#871016 Mobile: Apple App Store asks for bundle ID TestFlight

### DIFF
--- a/Tasks/app-store-release/Tests/L0.ts
+++ b/Tasks/app-store-release/Tests/L0.ts
@@ -231,7 +231,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId'), 'fastlane pilot upload with teamId should have been run.');
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -a com.microsoft.test.appId'), 'fastlane pilot upload with teamId should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -306,7 +306,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa --distribute_external true'), 'fastlane pilot upload -u creds-username -i mypackage.ipa --distribute_external true should have been run.');
+        assert(tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -a com.microsoft.test.appId --distribute_external true'), 'fastlane pilot upload -u creds-username -i mypackage.ipa --distribute_external true should have been run.');
         assert(tr.invokedToolCount === 1, 'should have run fastlane pilot.');
         assert(tr.succeeded, 'task should have succeeded');
         done();

--- a/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTesters.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTesters.ts
@@ -43,7 +43,7 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
-        "fastlane pilot upload -u creds-username -i mypackage.ipa --distribute_external true": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -a com.microsoft.test.appId --distribute_external true": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -a com.microsoft.test.appId": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -169,12 +169,14 @@ async function run() {
         if (releaseTrack === 'TestFlight') {
             // Run pilot (via fastlane) to upload to testflight
             let pilotCommand: ToolRunner = tl.tool('fastlane');
+            let bundleIdentifier: string = tl.getInput('appIdentifier', false);
             pilotCommand.arg(['pilot', 'upload', '-u', credentials.username, '-i', ipaPath]);
             if (isValidFilePath(releaseNotes)) {
                 pilotCommand.arg(['--changelog', fs.readFileSync(releaseNotes).toString()]);
             }
             pilotCommand.argIf(teamId, ['-q', teamId]);
             pilotCommand.argIf(teamName, ['-r', teamName]);
+            pilotCommand.argIf(bundleIdentifier, ['-a', bundleIdentifier]);
             pilotCommand.argIf(shouldSkipSubmission, ['--skip_submission', 'true']);
             pilotCommand.argIf(shouldSkipWaitingForProcessing, ['--skip_waiting_for_build_processing', 'true']);
 


### PR DESCRIPTION
See:  https://github.com/fastlane/fastlane/blob/eb0d3fe3979184f28cb501dc2d313b5a160bd7ef/pilot/lib/pilot/manager.rb#L53
The logic is to send the bundle ID when supplied, let fastlane do its detection when not.

This should work.  The link to fastlane shows that it checks the configuration first before looking through the ipa.