### PR TITLE
Support for MacOS with the -c arg for .PKG files in FastLane

### DIFF
--- a/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
@@ -20,8 +20,10 @@
   "loc.input.help.fastlaneSession": "Used with two-step verification.  Create by running: 'fastlane spaceauth -u [email]'",
   "loc.input.label.appIdentifier": "Bundle ID",
   "loc.input.help.appIdentifier": "The unique app identifier (e.g. com.myapp.etc). Required if the track is Production.",
-  "loc.input.label.ipaPath": "Binary Path",
-  "loc.input.help.ipaPath": "Path to the binary to publish (i.e. IPA). A glob pattern can be used but it must resolve to exactly one IPA file.",
+  "loc.input.label.appType": "Application Type",
+  "loc.input.help.appType": "The type of application you wish to submit",
+  "loc.input.label.appPath": "Binary Path",
+  "loc.input.help.appPath": "Path to the binary to publish (i.e. IPA or PKG). A glob pattern can be used but it must resolve to exactly one IPA or PKG file.",
   "loc.input.label.releaseTrack": "Track",
   "loc.input.label.skipBinaryUpload": "Skip Binary Upload",
   "loc.input.help.skipBinaryUpload": "Select to skip binary upload and only update metadata and screenshots.",
@@ -66,5 +68,6 @@
   "loc.messages.MultipleIpaFilesFound": "More than one IPA file found using pattern: %s",
   "loc.messages.FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
   "loc.messages.ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
-  "loc.messages.ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration."
+  "loc.messages.ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
+  "loc.messages.NotValidAppType": "An incorrect ApplicationType was chosen. Valid values osx, ios or appletvos. Value set: %s"
 }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -81,7 +81,7 @@ async function run() {
             }
         }
 
-        let filePath: string = tl.getInput('appPath', true);
+        let filePath: string = tl.getInput('ipaPath', true);
         let skipBinaryUpload: boolean = tl.getBoolInput('skipBinaryUpload', false);
         let uploadMetadata: boolean = tl.getBoolInput('uploadMetadata', false);
         let metadataPath: string = tl.getInput('metadataPath', false);
@@ -179,7 +179,7 @@ async function run() {
             // Run pilot (via fastlane) to upload to testflight
             let pilotCommand: ToolRunner = tl.tool('fastlane');
             let bundleIdentifier: string = tl.getInput('appIdentifier', false);
-            pilotCommand.arg(['pilot', 'upload', '-u', credentials.username, '-i', ipaPath]);
+            pilotCommand.arg(['pilot', 'upload', '-u', credentials.username, '-i', filePath]);
             let usingReleaseNotes: boolean = isValidFilePath(releaseNotes);
             if (usingReleaseNotes) {
                 pilotCommand.arg(['--changelog', fs.readFileSync(releaseNotes).toString()]);
@@ -214,19 +214,24 @@ async function run() {
             deliverCommand.arg(['deliver', '--force', '-u', credentials.username, '-a', bundleIdentifier]);
             deliverCommand.argIf(skipBinaryUpload, ['--skip_binary_upload', 'true']);
 
-            //Sets -i or -c depending if app submission is for (-i) iOS/TVOS or (-c) MacOS
+            //Sets -i or -c depending if app submission is for (-i) iOS/tvOS or (-c) MacOS
             switch (applicationType.toLocaleLowerCase()) {
-                case 'osx':
+                case 'macos':
                     // Use the -C flag &
                     deliverCommand.arg(['-c', filePath]);
-                    deliverCommand.arg(['-j', applicationType]);
+                    deliverCommand.arg(['-j', 'osx']); //Fastlane wants arg as OSX
                     break;
 
                 case 'ios':
-                case 'appletvos':
                     //Use the -I flag for ipa's
                     deliverCommand.arg(['-i', filePath]);
-                    deliverCommand.arg(['-j', applicationType]);
+                    deliverCommand.arg(['-j', 'ios']);
+                    break;
+
+                case 'tvos':
+                    //Use the -I flag for ipa's
+                    deliverCommand.arg(['-i', filePath]);
+                    deliverCommand.arg(['-j', 'appletvos']);
                     break;
 
                 default:

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "147",
+        "Minor": "150",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",
@@ -112,14 +112,15 @@
             "label": "Application Type",
             "helpMarkDown": "The type of application you wish to submit",
             "required": true,
+            "defaultValue": "iOS",
             "options": {
                 "iOS": "iOS",
-                "AppleTVOS": "AppleTVOS",
-                "OSX": "OSX"
+                "tvOS": "tvOS",
+                "macOS": "macOS"
             }
         },
         {
-            "name": "appPath",
+            "name": "ipaPath",
             "type": "filePath",
             "label": "Binary Path",
             "defaultValue": "**/*.ipa",
@@ -331,6 +332,6 @@
         "FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
         "ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
         "ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
-        "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values osx, ios or appletvos. Value set: %s"
+        "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s"
     }
 }

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -107,12 +107,24 @@
             "helpMarkDown": "The unique app identifier (e.g. com.myapp.etc). Required if the track is Production."
         },
         {
-            "name": "ipaPath",
+            "name": "appType",
+            "type": "pickList",
+            "label": "Application Type",
+            "helpMarkDown": "The type of application you wish to submit",
+            "required": true,
+            "options": {
+                "iOS": "iOS",
+                "AppleTVOS": "AppleTVOS",
+                "OSX": "OSX"
+            }
+        },
+        {
+            "name": "appPath",
             "type": "filePath",
             "label": "Binary Path",
             "defaultValue": "**/*.ipa",
             "required": true,
-            "helpMarkDown": "Path to the binary to publish (i.e. IPA). A glob pattern can be used but it must resolve to exactly one IPA file."
+            "helpMarkDown": "Path to the binary to publish (i.e. IPA or PKG). A glob pattern can be used but it must resolve to exactly one IPA or PKG file."
         },
         {
             "name": "releaseTrack",
@@ -318,6 +330,7 @@
         "MultipleIpaFilesFound": "More than one IPA file found using pattern: %s",
         "FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
         "ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
-        "ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration."
+        "ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
+        "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values osx, ios or appletvos. Value set: %s"
     }
 }

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -109,12 +109,24 @@
       "helpMarkDown": "ms-resource:loc.input.help.appIdentifier"
     },
     {
-      "name": "ipaPath",
+      "name": "appType",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.appType",
+      "helpMarkDown": "ms-resource:loc.input.help.appType",
+      "required": true,
+      "options": {
+        "iOS": "iOS",
+        "AppleTVOS": "AppleTVOS",
+        "OSX": "OSX"
+      }
+    },
+    {
+      "name": "appPath",
       "type": "filePath",
-      "label": "ms-resource:loc.input.label.ipaPath",
+      "label": "ms-resource:loc.input.label.appPath",
       "defaultValue": "**/*.ipa",
       "required": true,
-      "helpMarkDown": "ms-resource:loc.input.help.ipaPath"
+      "helpMarkDown": "ms-resource:loc.input.help.appPath"
     },
     {
       "name": "releaseTrack",
@@ -320,6 +332,7 @@
     "MultipleIpaFilesFound": "ms-resource:loc.messages.MultipleIpaFilesFound",
     "FastlaneSessionEmpty": "ms-resource:loc.messages.FastlaneSessionEmpty",
     "ReleaseNotesRequiredForExternalTesting": "ms-resource:loc.messages.ReleaseNotesRequiredForExternalTesting",
-    "ExternalTestersCannotSkipWarning": "ms-resource:loc.messages.ExternalTestersCannotSkipWarning"
+    "ExternalTestersCannotSkipWarning": "ms-resource:loc.messages.ExternalTestersCannotSkipWarning",
+    "NotValidAppType": "ms-resource:loc.messages.NotValidAppType"
   }
 }


### PR DESCRIPTION
Fixes #116 

* Renames ipaPath input to be appPath
* Update ipaPath description to mention it can be PKG
* Adds new dropdown for application type
* Switch logic for apptype to set the -i or -c arg
* Switch logic sets apptype with the -j arg