### PR TITLE
Fastlane arguments multiple parameters

### DIFF
--- a/Tasks/app-store-promote/Tests/L0.ts
+++ b/Tasks/app-store-promote/Tests/L0.ts
@@ -96,6 +96,7 @@ describe('app-store-promote L0 Suite', function () {
         tr.run();
         assert(tr.invokedToolCount === 1, 'should have run fastlane deliver.');
         assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --automatic_release --force --app-version 2.1.5'), 'should have run fastlane deliver with additional fastlane arguments.');
+        assert(tr.stdOutContained('##vso[task.debug]   2.1.5'), 'should have sent app-version parameter as a separate argument');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();

--- a/Tasks/app-store-promote/Tests/L0.ts
+++ b/Tasks/app-store-promote/Tests/L0.ts
@@ -87,7 +87,7 @@ describe('app-store-promote L0 Suite', function () {
         done();
     });
 
-    it('additional fastlane install', (done: MochaDone) => {
+    it('additional fastlane arguments', (done: MochaDone) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0AdditionalFastlaneArguments.js');

--- a/Tasks/app-store-promote/app-store-promote.ts
+++ b/Tasks/app-store-promote/app-store-promote.ts
@@ -152,7 +152,10 @@ async function run() {
         deliverCommand.argIf(teamId, ['-k', teamId]);
         deliverCommand.argIf(teamName, ['-e', teamName]);
         deliverCommand.arg('--force');
-        deliverCommand.argIf(fastlaneArguments, fastlaneArguments);
+
+        //use .line instead of arg/argif to support mulitple parameters input by user
+        if(fastlaneArguments)
+            deliverCommand.line(fastlaneArguments);
 
         await deliverCommand.exec();
 

--- a/Tasks/app-store-promote/app-store-promote.ts
+++ b/Tasks/app-store-promote/app-store-promote.ts
@@ -154,8 +154,9 @@ async function run() {
         deliverCommand.arg('--force');
 
         //use .line instead of arg/argif to support mulitple parameters input by user
-        if(fastlaneArguments)
+        if (fastlaneArguments) {
             deliverCommand.line(fastlaneArguments);
+        }
 
         await deliverCommand.exec();
 

--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "147",
+        "Minor": "175",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "147",
+    "Minor": "175",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",


### PR DESCRIPTION
Using .line instead of .argIf guarantes that if multiple arguments are provided they willl be passed correctly to child_process.spawn by the task-lib.

When using argif, the whole string from fastlaneArguments are put in one array item and are considered as just one parameter.

While the current test does confirm the arguments are indeed used, I believe the detail mentioned above is not captured by the test as the process and its arguments are likely joined by the mock test runner in just one string.

app-store-release task already uses .line to append fastlaneArguments.

closes #164 