### PR TITLE
[AppStoreReleaseV1] Replace shortcut '-e' with the '--team_name' option for the team name field

### DIFF
--- a/Tasks/app-store-promote/Tests/L0.ts
+++ b/Tasks/app-store-promote/Tests/L0.ts
@@ -249,7 +249,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -e teamName --force'), 'fastlane deliver with team name should have been run.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --team_name teamName --force'), 'fastlane deliver with team name should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -264,7 +264,7 @@ describe('app-store-promote L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId -e teamName --force'), 'fastlane deliver with team id and team name should have been run.');
+        assert(tr.ran('fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId --team_name teamName --force'), 'fastlane deliver with team id and team name should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
@@ -48,7 +48,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId -e teamName --force": {
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -k teamId --team_name teamName --force": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-promote/Tests/L0TeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamName.ts
@@ -47,7 +47,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true -e teamName --force": {
+        "fastlane deliver submit_build -u creds-username -a com.microsoft.test.appId --skip_binary_upload true --skip_metadata true --skip_screenshots true --team_name teamName --force": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-promote/app-store-promote.ts
+++ b/Tasks/app-store-promote/app-store-promote.ts
@@ -150,7 +150,7 @@ async function run() {
         deliverCommand.arg(['--skip_binary_upload', 'true', '--skip_metadata', 'true', '--skip_screenshots', 'true']);
         deliverCommand.argIf(shouldAutoRelease, '--automatic_release');
         deliverCommand.argIf(teamId, ['-k', teamId]);
-        deliverCommand.argIf(teamName, ['-e', teamName]);
+        deliverCommand.argIf(teamName, ['--team_name', teamName]);
         deliverCommand.arg('--force');
         deliverCommand.argIf(fastlaneArguments, fastlaneArguments);
 

--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "147",
+        "Minor": "175",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "147",
+    "Minor": "175",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/Tests/L0.ts
+++ b/Tasks/app-store-release/Tests/L0.ts
@@ -447,7 +447,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -e teamName'), 'fastlane deliver with teamName should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --team_name teamName'), 'fastlane deliver with teamName should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -462,7 +462,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId -e teamName'), 'fastlane deliver with teamId and teamName should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --team_name teamName'), 'fastlane deliver with teamId and teamName should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
@@ -55,7 +55,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId -e teamName": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --team_name teamName": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -e teamName": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --team_name teamName": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -177,6 +177,7 @@ async function run() {
         //gem update fastlane -i ~/.gem-cache
         if (releaseTrack === 'TestFlight') {
             // Run pilot (via fastlane) to upload to testflight
+            // See https://github.com/fastlane/fastlane/blob/master/pilot/lib/pilot/options.rb for more information on these arguments
             let pilotCommand: ToolRunner = tl.tool('fastlane');
             let bundleIdentifier: string = tl.getInput('appIdentifier', false);
             pilotCommand.arg(['pilot', 'upload', '-u', credentials.username, '-i', filePath]);
@@ -255,7 +256,7 @@ async function run() {
                 deliverCommand.arg(['--skip_screenshots', 'true']);
             }
             deliverCommand.argIf(teamId, ['-k', teamId]);
-            deliverCommand.argIf(teamName, ['-e', teamName]);
+            deliverCommand.argIf(teamName, ['--team_name', teamName]);
             deliverCommand.argIf(shouldSubmitForReview, ['--submit_for_review', 'true']);
             deliverCommand.argIf(shouldAutoRelease, ['--automatic_release', 'true']);
 

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "158",
+        "Minor": "175",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "158",
+    "Minor": "175",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",


### PR DESCRIPTION
**Task name**: AppStoreReleaseV1

**Description**:
From version 2.148.0 the Fastlane [recognizes](https://github.com/fastlane/fastlane/issues/16461#issuecomment-632055291) `-e` shortcut (that used for `teamName` field) as `env` option. That's why when the team name field specified in the `AppStoreRelease` task, Fastlane fails with  `Could not find option 'env' in the list of available options` error.

_Changes:_
- Shortcut `-e` replaced by the `--team_name` option to prevent `Could not find option 'env' in the list of available options` error

- Updated related unit-tests according to source code changes

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** 
- https://github.com/microsoft/app-store-vsts-extension/issues/152

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

**Results of unit-tests**:
![image](https://user-images.githubusercontent.com/14060121/91711435-8d7ec400-eb8e-11ea-96a8-15c6543dd7ee.png)
