### PR TITLE
[AppStoreExtension] Bump up extension version to 175

### DIFF
--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "147",
+        "Minor": "175",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "147",
+    "Minor": "175",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.158.0",
+    "version": "1.175.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Azure DevOps build or release pipeline",
     "categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.3.0",
+  "version": "1.175.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.3.0",
+  "version": "1.175.0",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: 
- IPA Resign

**Description**: 
Bumped up the task version to 175 to prepare for new release

*Changes:*
- Bumped up the task version to 175
- Bumped up the extension version to 175
- Bumped up the package.json version to 175

**Documentation changes required:** N

**Added unit tests:** N 

**Attached related issue:** 
- https://github.com/microsoft/build-task-team/issues/226

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/google-play-vsts-extension/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] All unit-tests passed 
![image](https://user-images.githubusercontent.com/64020607/92758587-8bd7ac00-f397-11ea-8c09-2da608ddb674.png)
