### PR TITLE
Update task-lib in tasks

### DIFF
--- a/Tasks/app-store-promote/Tests/L0.ts
+++ b/Tasks/app-store-promote/Tests/L0.ts
@@ -9,7 +9,7 @@
 
 import * as path from 'path';
 import * as assert from 'assert';
-import * as ttm from 'vsts-task-lib/mock-test';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('app-store-promote L0 Suite', function () {
     /* tslint:disable:no-empty */

--- a/Tasks/app-store-promote/Tests/L0AdditionalFastlaneArguments.ts
+++ b/Tasks/app-store-promote/Tests/L0AdditionalFastlaneArguments.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0AppSpecificPassword.ts
+++ b/Tasks/app-store-promote/Tests/L0AppSpecificPassword.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0AppSpecificPasswordEndPoint.ts
+++ b/Tasks/app-store-promote/Tests/L0AppSpecificPasswordEndPoint.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
+++ b/Tasks/app-store-promote/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
@@ -34,7 +34,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-promote/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
+++ b/Tasks/app-store-promote/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
+++ b/Tasks/app-store-promote/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
+++ b/Tasks/app-store-promote/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
@@ -36,7 +36,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-promote/Tests/L0BuildNumber.ts
+++ b/Tasks/app-store-promote/Tests/L0BuildNumber.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0EnforceDarwin.ts
+++ b/Tasks/app-store-promote/Tests/L0EnforceDarwin.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import tmrm = require('vsts-task-lib/mock-run');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0GemCacheEnvVar.ts
+++ b/Tasks/app-store-promote/Tests/L0GemCacheEnvVar.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0LatestBuild.ts
+++ b/Tasks/app-store-promote/Tests/L0LatestBuild.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0NoBundleId.ts
+++ b/Tasks/app-store-promote/Tests/L0NoBundleId.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0NoChooseBuild.ts
+++ b/Tasks/app-store-promote/Tests/L0NoChooseBuild.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0NoFastlaneInstall.ts
+++ b/Tasks/app-store-promote/Tests/L0NoFastlaneInstall.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0ServiceEndpointDeliver.ts
+++ b/Tasks/app-store-promote/Tests/L0ServiceEndpointDeliver.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0ShouldAutoRelease.ts
+++ b/Tasks/app-store-promote/Tests/L0ShouldAutoRelease.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0SpecificFastlaneInstall.ts
+++ b/Tasks/app-store-promote/Tests/L0SpecificFastlaneInstall.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0SpecificFastlaneInstallNoVersion.ts
+++ b/Tasks/app-store-promote/Tests/L0SpecificFastlaneInstallNoVersion.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0TeamId.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamId.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamIdTeamName.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0TeamName.ts
+++ b/Tasks/app-store-promote/Tests/L0TeamName.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/Tests/L0UserPassDeliver.ts
+++ b/Tasks/app-store-promote/Tests/L0UserPassDeliver.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-promote/app-store-promote.ts
+++ b/Tasks/app-store-promote/app-store-promote.ts
@@ -6,9 +6,9 @@
 
 import os = require('os');
 import path = require('path');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 
 export class UserCredentials {
     username: string;

--- a/Tasks/app-store-promote/package-lock.json
+++ b/Tasks/app-store-promote/package-lock.json
@@ -4,6 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "azure-pipelines-task-lib": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.11.1.tgz",
+      "integrity": "sha512-y57uWaMWEOCqFommNj1xeyb/76rDSq/l5D0PHTPpK64RdH3fCWs3hAqLETFP//NiI4VZrJxbzS16V/txYpJZoA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "sync-request": "3.0.1",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -18,10 +37,36 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "glob": {
       "version": "6.0.4",
@@ -34,6 +79,21 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "http-basic": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^1.0.0"
+      }
+    },
+    "http-response-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
     },
     "inflight": {
       "version": "1.0.6",
@@ -48,6 +108,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -80,10 +145,47 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
       "version": "5.6.0",
@@ -94,6 +196,52 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "sync-request": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
+      "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "http-response-object": "^1.0.1",
+        "then-request": "^2.0.1"
+      }
+    },
+    "then-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.7",
+        "http-basic": "^2.5.1",
+        "http-response-object": "^1.1.0",
+        "promise": "^7.1.1",
+        "qs": "^6.1.0"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "vso-node-api": {
       "version": "0.6.1",

--- a/Tasks/app-store-promote/package-lock.json
+++ b/Tasks/app-store-promote/package-lock.json
@@ -68,18 +68,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
     "http-basic": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
@@ -94,15 +82,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
       "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -126,24 +105,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -242,34 +203,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "^1.0.1"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.9.20.tgz",
-      "integrity": "sha1-MbFJAXkbOyFytAiZDF4bzop57Zs=",
-      "requires": {
-        "glob": "^6.0.1",
-        "minimatch": "^3.0.0",
-        "mockery": "^1.7.0",
-        "node-uuid": "^1.4.7",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "vso-node-api": "^0.6.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/Tasks/app-store-promote/package.json
+++ b/Tasks/app-store-promote/package.json
@@ -4,6 +4,7 @@
   "description": "Azure Pipelines task to promote a build in the Apple App Store",
   "main": "app-store-promote.js",
   "dependencies": {
+    "azure-pipelines-task-lib": "^2.11.1",
     "vsts-task-lib": "^0.9.7"
   },
   "devDependencies": {},

--- a/Tasks/app-store-promote/package.json
+++ b/Tasks/app-store-promote/package.json
@@ -4,8 +4,7 @@
   "description": "Azure Pipelines task to promote a build in the Apple App Store",
   "main": "app-store-promote.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.11.1",
-    "vsts-task-lib": "^0.9.7"
+    "azure-pipelines-task-lib": "^2.11.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "175",
+        "Minor": "176",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "175",
+    "Minor": "176",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/Tests/L0.ts
+++ b/Tasks/app-store-release/Tests/L0.ts
@@ -9,7 +9,7 @@
 
 import * as path from 'path';
 import * as assert from 'assert';
-import * as ttm from 'vsts-task-lib/mock-test';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('app-store-release L0 Suite', function () {
     /* tslint:disable:no-empty */

--- a/Tasks/app-store-release/Tests/L0AppSpecificPassword.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPassword.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0AppSpecificPassword.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPassword.ts
@@ -38,7 +38,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPoint.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPoint.ts
@@ -35,7 +35,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPoint.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPoint.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
@@ -35,7 +35,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
+++ b/Tasks/app-store-release/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
@@ -37,7 +37,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0EnforceDarwin.ts
+++ b/Tasks/app-store-release/Tests/L0EnforceDarwin.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import tmrm = require('vsts-task-lib/mock-run');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0GemCacheEnvVar.ts
+++ b/Tasks/app-store-release/Tests/L0GemCacheEnvVar.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0GemCacheEnvVar.ts
+++ b/Tasks/app-store-release/Tests/L0GemCacheEnvVar.ts
@@ -38,7 +38,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0NoAuthType.ts
+++ b/Tasks/app-store-release/Tests/L0NoAuthType.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0NoEndpoint.ts
+++ b/Tasks/app-store-release/Tests/L0NoEndpoint.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0NoUserPass.ts
+++ b/Tasks/app-store-release/Tests/L0NoUserPass.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionFastlaneArguments.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionFastlaneArguments.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionFastlaneArguments.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionFastlaneArguments.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionMacApp.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionMacApp.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionMacApp.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionMacApp.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.app": [
             "mypackage.app"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionMultipleIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionMultipleIpaFiles.ts
@@ -35,7 +35,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
             "files/first.ipa",
             "files/second.ipa"

--- a/Tasks/app-store-release/Tests/L0ProductionMultipleIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionMultipleIpaFiles.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionNoBundleId.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionNoBundleId.ts
@@ -39,7 +39,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionNoBundleId.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionNoBundleId.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionNoIpaPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionNoIpaPath.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionOneIpaFile.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionOneIpaFile.ts
@@ -39,7 +39,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionOneIpaFile.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionOneIpaFile.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionShouldAutoRelease.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldAutoRelease.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionShouldAutoRelease.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldAutoRelease.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionShouldSkipBinaryUpload.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldSkipBinaryUpload.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionShouldSkipBinaryUpload.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldSkipBinaryUpload.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionShouldSubmitForReview.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldSubmitForReview.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionShouldSubmitForReview.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionShouldSubmitForReview.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionTVApp.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTVApp.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionTVApp.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTVApp.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamId.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
@@ -41,7 +41,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamIdTeamName.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionTeamName.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionUploadMetadataMetadataPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionUploadMetadataMetadataPath.ts
@@ -41,7 +41,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionUploadMetadataMetadataPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionUploadMetadataMetadataPath.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
@@ -41,7 +41,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0ProductionZeroIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionZeroIpaFiles.ts
@@ -35,7 +35,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
         ]
     }

--- a/Tasks/app-store-release/Tests/L0ProductionZeroIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0ProductionZeroIpaFiles.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersNoReleaseNotes.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersNoReleaseNotes.ts
@@ -38,7 +38,7 @@ let myAnswers: string = `{
         "/usr/bin/fastlane": true,
         "/usr/bin/pilot": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersNoReleaseNotes.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersNoReleaseNotes.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
@@ -57,7 +57,7 @@ let myAnswers: string = `{
         "/usr/bin/fastlane": true,
         "/usr/bin/pilot": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');

--- a/Tasks/app-store-release/Tests/L0TestFlightFastlaneArguments.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightFastlaneArguments.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightFastlaneArguments.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightFastlaneArguments.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightMultipleIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightMultipleIpaFiles.ts
@@ -36,7 +36,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
             "files/first.ipa",
             "files/second.ipa"

--- a/Tasks/app-store-release/Tests/L0TestFlightMultipleIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightMultipleIpaFiles.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightNoFastlaneInstall.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightNoFastlaneInstall.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightNoFastlaneInstall.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightNoFastlaneInstall.ts
@@ -36,7 +36,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightNoIpaPath.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightNoIpaPath.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightOneIpaFile.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightOneIpaFile.ts
@@ -39,7 +39,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightOneIpaFile.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightOneIpaFile.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightServiceEndpoint.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightServiceEndpoint.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightServiceEndpoint.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightServiceEndpoint.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightShouldSkipSubmission.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightShouldSkipSubmission.ts
@@ -39,7 +39,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightShouldSkipSubmission.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightShouldSkipSubmission.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
@@ -39,7 +39,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstall.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstall.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstall.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstall.ts
@@ -37,7 +37,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstallNoVersion.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstallNoVersion.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstallNoVersion.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightSpecificFastlaneInstallNoVersion.ts
@@ -37,7 +37,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamId.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamIdTeamName.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamIdTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamIdTeamName.ts
@@ -40,7 +40,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamName.ts
@@ -39,7 +39,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightTeamName.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightTeamName.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightUserPass.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightUserPass.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/Tests/L0TestFlightUserPass.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightUserPass.ts
@@ -37,7 +37,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "mypackage.ipa": [
             "mypackage.ipa"
         ]

--- a/Tasks/app-store-release/Tests/L0TestFlightZeroIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightZeroIpaFiles.ts
@@ -36,7 +36,7 @@ let myAnswers: string = `{
         "/usr/bin/gem": true,
         "/usr/bin/fastlane": true
     },
-    "glob": {
+    "findMatch": {
         "**/*.ipa": [
         ]
     },

--- a/Tasks/app-store-release/Tests/L0TestFlightZeroIpaFiles.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightZeroIpaFiles.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -7,9 +7,9 @@
 import fs = require('fs');
 import os = require('os');
 import path = require('path');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 
 class UserCredentials {
     username: string;
@@ -33,7 +33,7 @@ function isValidFilePath(filePath: string): boolean {
 // Attempts to find a single ipa file to use by the task.
 // If a glob pattern is provided, only a single ipa is allowed.
 function findIpa(ipaPath: string): string {
-    let paths: string[] = tl.glob(ipaPath);
+    let paths: string[] = tl.findMatch('', ipaPath);
     if (!paths || paths.length === 0) {
         throw new Error(tl.loc('NoIpaFilesFound', ipaPath));
     }

--- a/Tasks/app-store-release/package-lock.json
+++ b/Tasks/app-store-release/package-lock.json
@@ -4,6 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "azure-pipelines-task-lib": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.11.1.tgz",
+      "integrity": "sha512-y57uWaMWEOCqFommNj1xeyb/76rDSq/l5D0PHTPpK64RdH3fCWs3hAqLETFP//NiI4VZrJxbzS16V/txYpJZoA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "sync-request": "3.0.1",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -18,10 +37,36 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "glob": {
       "version": "6.0.4",
@@ -34,6 +79,21 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "http-basic": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^1.0.0"
+      }
+    },
+    "http-response-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
     },
     "inflight": {
       "version": "1.0.6",
@@ -48,6 +108,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -80,10 +145,47 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
       "version": "5.6.0",
@@ -94,6 +196,52 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "sync-request": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
+      "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "http-response-object": "^1.0.1",
+        "then-request": "^2.0.1"
+      }
+    },
+    "then-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.7",
+        "http-basic": "^2.5.1",
+        "http-response-object": "^1.1.0",
+        "promise": "^7.1.1",
+        "qs": "^6.1.0"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "vso-node-api": {
       "version": "0.6.1",

--- a/Tasks/app-store-release/package-lock.json
+++ b/Tasks/app-store-release/package-lock.json
@@ -68,18 +68,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
     "http-basic": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
@@ -94,15 +82,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
       "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -126,24 +105,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -242,34 +203,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "^1.0.1"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.9.20.tgz",
-      "integrity": "sha1-MbFJAXkbOyFytAiZDF4bzop57Zs=",
-      "requires": {
-        "glob": "^6.0.1",
-        "minimatch": "^3.0.0",
-        "mockery": "^1.7.0",
-        "node-uuid": "^1.4.7",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "vso-node-api": "^0.6.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/Tasks/app-store-release/package.json
+++ b/Tasks/app-store-release/package.json
@@ -4,8 +4,7 @@
   "description": "Azure Pipelines task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.11.1",
-    "vsts-task-lib": "^0.9.7"
+    "azure-pipelines-task-lib": "^2.11.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/Tasks/app-store-release/package.json
+++ b/Tasks/app-store-release/package.json
@@ -4,6 +4,7 @@
   "description": "Azure Pipelines task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {
+    "azure-pipelines-task-lib": "^2.11.1",
     "vsts-task-lib": "^0.9.7"
   },
   "devDependencies": {},

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "175",
+        "Minor": "176",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "175",
+    "Minor": "176",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/Tests/L0.ts
+++ b/Tasks/ipa-resign/Tests/L0.ts
@@ -9,7 +9,7 @@
 
 import * as path from 'path';
 import * as assert from 'assert';
-import * as ttm from 'vsts-task-lib/mock-test';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('ipa-resign L0 Suite', function () {
     /* tslint:disable:no-empty */

--- a/Tasks/ipa-resign/Tests/L0EnforceDarwin.ts
+++ b/Tasks/ipa-resign/Tests/L0EnforceDarwin.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import tmrm = require('vsts-task-lib/mock-run');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/ipa-resign/ios-signing-common.ts
+++ b/Tasks/ipa-resign/ios-signing-common.ts
@@ -1,7 +1,7 @@
 import fs = require('fs');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 
 let userProvisioningProfilesPath: string = tl.resolve(tl.getVariable('HOME'), 'Library', 'MobileDevice', 'Provisioning Profiles');
 

--- a/Tasks/ipa-resign/ipa-resign.ts
+++ b/Tasks/ipa-resign/ipa-resign.ts
@@ -1,9 +1,9 @@
 import os = require('os');
 import path = require('path');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import sign = require('./ios-signing-common');
 
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 
 function findMatchExactlyOne(defaultRoot: string, pattern: string): string {
     let files: Array<string> = tl.findMatch(defaultRoot, pattern);

--- a/Tasks/ipa-resign/package-lock.json
+++ b/Tasks/ipa-resign/package-lock.json
@@ -4,6 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "azure-pipelines-task-lib": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.11.1.tgz",
+      "integrity": "sha512-y57uWaMWEOCqFommNj1xeyb/76rDSq/l5D0PHTPpK64RdH3fCWs3hAqLETFP//NiI4VZrJxbzS16V/txYpJZoA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "sync-request": "3.0.1",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -18,10 +37,61 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "http-basic": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^1.0.0"
+      }
+    },
+    "http-response-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -36,10 +106,47 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
       "version": "5.6.0",
@@ -50,6 +157,47 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "sync-request": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
+      "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "http-response-object": "^1.0.1",
+        "then-request": "^2.0.1"
+      }
+    },
+    "then-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.7",
+        "http-basic": "^2.5.1",
+        "http-response-object": "^1.1.0",
+        "promise": "^7.1.1",
+        "qs": "^6.1.0"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",

--- a/Tasks/ipa-resign/package-lock.json
+++ b/Tasks/ipa-resign/package-lock.json
@@ -203,19 +203,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "vsts-task-lib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.7.0.tgz",
-      "integrity": "sha512-zQqgneIZG3VY84RoIzkQr07r9fDH3lPpj6Qp07K89co/vyFznWJYpkjcdxubQm1YvgNu/P0yWYLdDruHyGGdtA==",
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
-      }
     }
   }
 }

--- a/Tasks/ipa-resign/package.json
+++ b/Tasks/ipa-resign/package.json
@@ -4,6 +4,7 @@
   "description": "Azure Pipelines task to resign an ipa file",
   "main": "ipa-resign.js",
   "dependencies": {
+    "azure-pipelines-task-lib": "^2.11.1",
     "vsts-task-lib": "^2.0.0-preview"
   },
   "devDependencies": {},

--- a/Tasks/ipa-resign/package.json
+++ b/Tasks/ipa-resign/package.json
@@ -4,8 +4,7 @@
   "description": "Azure Pipelines task to resign an ipa file",
   "main": "ipa-resign.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.11.1",
-    "vsts-task-lib": "^2.0.0-preview"
+    "azure-pipelines-task-lib": "^2.11.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "175",
+        "Minor": "176",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "175",
+    "Minor": "176",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",


### PR DESCRIPTION
**Task name**:  app-store-promote, app-store-release, ipa-resign

**Description**: 
- Changed deprecated `vsts-task-lib` to `azure-pipelines-task-lib` in tasks
- Changed `glob` property to `findMatch` in `app-store-release` task since `glob` property doesn't exist in the `azure-pipelines-task-lib`

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** #159, [#12147](https://github.com/microsoft/azure-pipelines-tasks/issues/12147)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] All unit-tests passed
![image](https://user-images.githubusercontent.com/64020607/94072165-dcbabc00-fdfd-11ea-857a-bf32c58c22de.png)

