### PR TITLE
Fixed issue with groups name formatting

### DIFF
--- a/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
@@ -71,7 +71,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa --changelog Release notes for beta release. -a com.microsoft.test.appId --distribute_external true --groups Group1,Group 2": {        
+        "fastlane pilot upload -u creds-username -i mypackage.ipa --changelog Release notes for beta release. -a com.microsoft.test.appId --distribute_external true --groups \\"Group1,Group 2\\"": {        
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -203,7 +203,7 @@ async function run() {
                 }
 
                 let externalTestersGroups: string = tl.getInput('externalTestersGroups');
-                pilotCommand.argIf(externalTestersGroups, ['--groups', externalTestersGroups]);
+                pilotCommand.argIf(externalTestersGroups, ['--groups', `"${externalTestersGroups}"`]);
             }
 
             if (fastlaneArguments) {

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "176",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "176",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Task name: AppStoreRelease

Description: fixes issue with incorrect formatting of groups value for fastlane cli (value should be in double quotes)

Documentation changes required: N

Added unit tests: N

Attached related issue: https://github.com/microsoft/app-store-vsts-extension/issues/171

Checklist:
- [x] Task version was bumped - please check instruction how to do it
- [x] Checked that applied changes work as expected