### PR TITLE
Made ipaPath optional

### DIFF
--- a/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
@@ -70,5 +70,5 @@
   "loc.messages.ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
   "loc.messages.ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
   "loc.messages.NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
-  "loc.messages.ipaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false"
+  "loc.messages.IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false"
 }

--- a/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/app-store-release/Strings/resources.resjson/en-US/resources.resjson
@@ -69,5 +69,6 @@
   "loc.messages.FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
   "loc.messages.ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
   "loc.messages.ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
-  "loc.messages.NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s"
+  "loc.messages.NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
+  "loc.messages.ipaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false"
 }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -131,7 +131,7 @@ async function run() {
 
         if (!skipBinaryUpload) {
             if (!filePath) {
-                throw new Error(tl.loc('ipaPathNotSpecified'));
+                throw new Error(tl.loc('IpaPathNotSpecified'));
             }
             // Ensure there's exactly one ipa before installing fastlane tools
             filePath = findIpa(filePath);

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -228,19 +228,25 @@ async function run() {
             switch (applicationType.toLocaleLowerCase()) {
                 case 'macos':
                     // Use the -C flag for apps
-                    deliverCommand.arg(['-c', filePath]);
+                    if (!skipBinaryUpload) {
+                        deliverCommand.arg(['-c', filePath]);
+                    }
                     deliverCommand.arg(['-j', 'osx']); //Fastlane wants arg as OSX
                     break;
 
                 case 'ios':
                     //Use the -I flag for ipa's
-                    deliverCommand.arg(['-i', filePath]);
+                    if (!skipBinaryUpload) {
+                        deliverCommand.arg(['-i', filePath]);
+                    }
                     deliverCommand.arg(['-j', 'ios']);
                     break;
 
                 case 'tvos':
                     //Use the -I flag for ipa's
-                    deliverCommand.arg(['-i', filePath]);
+                    if (!skipBinaryUpload) {
+                        deliverCommand.arg(['-i', filePath]);
+                    }
                     deliverCommand.arg(['-j', 'appletvos']);
                     break;
 

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -81,7 +81,7 @@ async function run() {
             }
         }
 
-        let filePath: string = tl.getInput('ipaPath', true);
+        let filePath: string = tl.getInput('ipaPath', false);
         let skipBinaryUpload: boolean = tl.getBoolInput('skipBinaryUpload', false);
         let uploadMetadata: boolean = tl.getBoolInput('uploadMetadata', false);
         let metadataPath: string = tl.getInput('metadataPath', false);
@@ -129,8 +129,13 @@ async function run() {
         // Add bin of new gem home so we don't have to resolve it later
         process.env['PATH'] = process.env['PATH'] + ':' + gemCache + path.sep + 'bin';
 
-        // Ensure there's exactly one ipa before installing fastlane tools
-        filePath = findIpa(filePath);
+        if (!skipBinaryUpload) {
+            if (!filePath) {
+                throw new Error(tl.loc('ipaPathNotSpecified'));
+            }
+            // Ensure there's exactly one ipa before installing fastlane tools
+            filePath = findIpa(filePath);
+        }
 
         // Install the ruby gem for fastlane
         tl.debug('Checking for ruby install...');

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -124,8 +124,9 @@
             "type": "filePath",
             "label": "Binary Path",
             "defaultValue": "**/*.ipa",
-            "required": true,
-            "helpMarkDown": "Path to the binary to publish (i.e. IPA or PKG). A glob pattern can be used but it must resolve to exactly one IPA or PKG file."
+            "required": false,
+            "helpMarkDown": "Path to the binary to publish (i.e. IPA or PKG). A glob pattern can be used but it must resolve to exactly one IPA or PKG file.",
+            "visibleRule": "skipBinaryUpload = false"
         },
         {
             "name": "releaseTrack",
@@ -332,6 +333,7 @@
         "FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
         "ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
         "ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
-        "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s"
+        "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
+        "ipaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false"
     }
 }

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "176",
+        "Minor": "177",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -334,6 +334,6 @@
         "ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
         "ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
         "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
-        "ipaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false"
+        "IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false"
     }
 }

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "176",
+    "Minor": "177",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -126,8 +126,9 @@
       "type": "filePath",
       "label": "ms-resource:loc.input.label.ipaPath",
       "defaultValue": "**/*.ipa",
-      "required": true,
-      "helpMarkDown": "ms-resource:loc.input.help.ipaPath"
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.ipaPath",
+      "visibleRule": "skipBinaryUpload = false"
     },
     {
       "name": "releaseTrack",
@@ -334,6 +335,7 @@
     "FastlaneSessionEmpty": "ms-resource:loc.messages.FastlaneSessionEmpty",
     "ReleaseNotesRequiredForExternalTesting": "ms-resource:loc.messages.ReleaseNotesRequiredForExternalTesting",
     "ExternalTestersCannotSkipWarning": "ms-resource:loc.messages.ExternalTestersCannotSkipWarning",
-    "NotValidAppType": "ms-resource:loc.messages.NotValidAppType"
+    "NotValidAppType": "ms-resource:loc.messages.NotValidAppType",
+    "ipaPathNotSpecified": "ms-resource:loc.messages.ipaPathNotSpecified"
   }
 }

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -336,6 +336,6 @@
     "ReleaseNotesRequiredForExternalTesting": "ms-resource:loc.messages.ReleaseNotesRequiredForExternalTesting",
     "ExternalTestersCannotSkipWarning": "ms-resource:loc.messages.ExternalTestersCannotSkipWarning",
     "NotValidAppType": "ms-resource:loc.messages.NotValidAppType",
-    "ipaPathNotSpecified": "ms-resource:loc.messages.ipaPathNotSpecified"
+    "IpaPathNotSpecified": "ms-resource:loc.messages.IpaPathNotSpecified"
   }
 }


### PR DESCRIPTION
Task name: app-store-release

Description: since task has 'Skip Binary Upload' 

Documentation changes required: Y

Added unit tests: N

Attached related issue: https://github.com/microsoft/app-store-vsts-extension/issues/174

Checklist:

- [x] Task version was bumped - please check instruction how to do it
- [ ] Checked that applied changes work as expected