### PR TITLE
[AppStorePromoteV1 / IpaResignV1] Bump extension version to 177

### DIFF
--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "176",
+        "Minor": "177",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "176",
+    "Minor": "177",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "176",
+        "Minor": "177",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "176",
+    "Minor": "177",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.176.0",
+  "version": "1.177.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.176.0",
+  "version": "1.177.0",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: AppStorePromoteV1 , IpaResignV1

**Description**: 
Bumped tasks version to 177 to prepare for the new release

_Changes_:

* Bump up AppStorePromote task minor version to 177 
* Bump up IpaResign task minor version to 177
* Bump up package.json minor version to 177

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** 
- https://github.com/microsoft/build-task-team/issues/327

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

**Results of unit-tests:**
![image](https://user-images.githubusercontent.com/14060121/97310052-dc399900-1873-11eb-9b85-b821cd870d4e.png)
