### PR TITLE
[AppStoreRelease] Fix  task.json structure

### DIFF
--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "177",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Submit to the App Store for review",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "177",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "177",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",
@@ -120,6 +120,16 @@
             }
         },
         {
+            "name": "skipBinaryUpload",
+            "type": "boolean",
+            "label": "Skip Binary Upload",
+            "required": false,
+            "defaultValue": false,
+            "helpMarkDown": "Select to skip binary upload and only update metadata and screenshots. Please note that with enabling this option you also need to pass --description or --pkg as additional fastlane parameters.",
+            "groupName": "releaseOptions",
+            "visibleRule": "releaseTrack = Production"
+        },
+        {
             "name": "ipaPath",
             "type": "filePath",
             "label": "Binary Path",
@@ -139,16 +149,6 @@
                 "TestFlight": "TestFlight"
             },
             "groupName": "releaseOptions"
-        },
-        {
-            "name": "skipBinaryUpload",
-            "type": "boolean",
-            "label": "Skip Binary Upload",
-            "required": false,
-            "defaultValue": false,
-            "helpMarkDown": "Select to skip binary upload and only update metadata and screenshots. Please note that with enabling this option you also need to pass --description or --pkg as additional fastlane parameters.",
-            "groupName": "releaseOptions",
-            "visibleRule": "releaseTrack = Production"
         },
         {
             "name": "uploadMetadata",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "177",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -122,6 +122,16 @@
       }
     },
     {
+      "name": "skipBinaryUpload",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.skipBinaryUpload",
+      "required": false,
+      "defaultValue": false,
+      "helpMarkDown": "ms-resource:loc.input.help.skipBinaryUpload",
+      "groupName": "releaseOptions",
+      "visibleRule": "releaseTrack = Production"
+    },
+    {
       "name": "ipaPath",
       "type": "filePath",
       "label": "ms-resource:loc.input.label.ipaPath",
@@ -141,16 +151,6 @@
         "TestFlight": "TestFlight"
       },
       "groupName": "releaseOptions"
-    },
-    {
-      "name": "skipBinaryUpload",
-      "type": "boolean",
-      "label": "ms-resource:loc.input.label.skipBinaryUpload",
-      "required": false,
-      "defaultValue": false,
-      "helpMarkDown": "ms-resource:loc.input.help.skipBinaryUpload",
-      "groupName": "releaseOptions",
-      "visibleRule": "releaseTrack = Production"
     },
     {
       "name": "uploadMetadata",

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": "1",
         "Minor": "177",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Resign ipa file",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "1",
     "Minor": "177",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.177.0",
+    "version": "1.177.1",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Azure DevOps build or release pipeline",
     "categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.177.0",
+  "version": "1.177.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.177.0",
+  "version": "1.177.1",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**:  AppStoreRelease

**Description**: 
The `ipaPath` behavior depends on `skipBinaryUpload`, but in the current JSON file, `skipBinaryUpload` was set after ʻIpaPath` which cause a validation error when we try to upload a new release to Microsoft marketplace.

_Changes_:
* Put the skipBinaryUpload before the ipaPath because
* Bump up extension version to 177.1

**Documentation changes required:** No
**Added unit tests:** No

**Attached related issue:**
- https://github.com/microsoft/build-task-team/issues/327

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
