### PR TITLE
[AppStoreRelease] Allow broken symbolic links for findMatch

### DIFF
--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -37,7 +37,7 @@ function findIpa(ipaPath: string): string {
         allowBrokenSymbolicLinks: true,
         followSymbolicLinks: true,
         followSpecifiedSymbolicLink: true
-    }
+    };
 
     let paths: string[] = tl.findMatch('', ipaPath, findOptions);
     if (!paths || paths.length === 0) {

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -40,7 +40,7 @@ function findIpa(ipaPath: string): string {
         followSpecifiedSymbolicLink: true
     };
 
-    let paths: string[] = tl.findMatch('', ipaPath, findOptions);
+    const paths: string[] = tl.findMatch('', ipaPath, findOptions);
     if (!paths || paths.length === 0) {
         throw new Error(tl.loc('NoIpaFilesFound', ipaPath));
     }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -33,6 +33,7 @@ function isValidFilePath(filePath: string): boolean {
 // Attempts to find a single ipa file to use by the task.
 // If a glob pattern is provided, only a single ipa is allowed.
 function findIpa(ipaPath: string): string {
+    // We need to allow broken symlinks since there could be broken symlinks found in source folder, but filtered by contents pattern
     const findOptions: tl.FindOptions = {
         allowBrokenSymbolicLinks: true,
         followSymbolicLinks: true,

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -33,7 +33,13 @@ function isValidFilePath(filePath: string): boolean {
 // Attempts to find a single ipa file to use by the task.
 // If a glob pattern is provided, only a single ipa is allowed.
 function findIpa(ipaPath: string): string {
-    let paths: string[] = tl.findMatch('', ipaPath);
+    const findOptions: tl.FindOptions = {
+        allowBrokenSymbolicLinks: true,
+        followSymbolicLinks: true,
+        followSpecifiedSymbolicLink: true
+    }
+
+    let paths: string[] = tl.findMatch('', ipaPath, findOptions);
     if (!paths || paths.length === 0) {
         throw new Error(tl.loc('NoIpaFilesFound', ipaPath));
     }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -33,7 +33,7 @@ function isValidFilePath(filePath: string): boolean {
 // Attempts to find a single ipa file to use by the task.
 // If a glob pattern is provided, only a single ipa is allowed.
 function findIpa(ipaPath: string): string {
-    // We need to allow broken symlinks since there could be broken symlinks found in source folder, but filtered by contents pattern
+    // We need to allow broken symlinks since there could be broken symlinks found in build output folder, but filtered by ipaPath pattern
     const findOptions: tl.FindOptions = {
         allowBrokenSymbolicLinks: true,
         followSymbolicLinks: true,

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -13,8 +13,8 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "177",
-        "Patch": "2"
+        "Minor": "178",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -15,8 +15,8 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "177",
-    "Patch": "2"
+    "Minor": "178",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**:  AppStoreRelease

**Description**: Added support for broken symbolic links in findMatch method

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #177 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
