### PR TITLE
[AppStoreReleaseV1] Fix the "Binary Path" input visibility

### DIFF
--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "178",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",
@@ -148,7 +148,7 @@
             "defaultValue": "**/*.ipa",
             "required": false,
             "helpMarkDown": "Path to the binary to publish (i.e. IPA or PKG). A glob pattern can be used but it must resolve to exactly one IPA or PKG file.",
-            "visibleRule": "skipBinaryUpload = false"
+            "visibleRule": "skipBinaryUpload = false || releaseTrack = TestFlight"
         },
         {
             "name": "uploadMetadata",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "178",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -150,7 +150,7 @@
       "defaultValue": "**/*.ipa",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.ipaPath",
-      "visibleRule": "skipBinaryUpload = false"
+      "visibleRule": "skipBinaryUpload = false || releaseTrack = TestFlight"
     },
     {
       "name": "uploadMetadata",


### PR DESCRIPTION
**Task name**:  
- AppStoreReleaseV1

**Description**: 
This PR fixes the problem with the visibility of `Binary Path` field when the user selected release to `TestFlight` track

_Changes:_
- Fixed `visibleRule` for `ipaPath` input 


**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** 

- https://github.com/microsoft/app-store-vsts-extension/issues/191

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
