### PR TITLE
[AppStoreRelease] Reverted PR #175 + prepared release 178

### DIFF
--- a/Tasks/app-store-promote/task.json
+++ b/Tasks/app-store-promote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "177",
+        "Minor": "178",
         "Patch": "2"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-promote/task.loc.json
+++ b/Tasks/app-store-promote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "177",
+    "Minor": "178",
     "Patch": "2"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
+++ b/Tasks/app-store-release/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
@@ -71,7 +71,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa --changelog Release notes for beta release. -a com.microsoft.test.appId --distribute_external true --groups \\"Group1,Group 2\\"": {        
+        "fastlane pilot upload -u creds-username -i mypackage.ipa --changelog Release notes for beta release. -a com.microsoft.test.appId --distribute_external true --groups Group1,Group 2": {        
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/app-store-release/app-store-release.ts
+++ b/Tasks/app-store-release/app-store-release.ts
@@ -230,7 +230,7 @@ async function run() {
                 }
 
                 let externalTestersGroups: string = tl.getInput('externalTestersGroups');
-                pilotCommand.argIf(externalTestersGroups, ['--groups', `"${externalTestersGroups}"`]);
+                pilotCommand.argIf(externalTestersGroups, ['--groups', externalTestersGroups]);
             }
 
             if (fastlaneArguments) {

--- a/Tasks/app-store-release/task.json
+++ b/Tasks/app-store-release/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "178",
-        "Patch": "1"
+        "Patch": "2"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",

--- a/Tasks/app-store-release/task.loc.json
+++ b/Tasks/app-store-release/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "178",
-    "Patch": "1"
+    "Patch": "2"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/ipa-resign/task.json
+++ b/Tasks/ipa-resign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "177",
+        "Minor": "178",
         "Patch": "2"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/ipa-resign/task.loc.json
+++ b/Tasks/ipa-resign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "177",
+    "Minor": "178",
     "Patch": "2"
   },
   "minimumAgentVersion": "1.95.3",

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.177.2",
+    "version": "1.178.2",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Azure DevOps build or release pipeline",
     "categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.177.2",
+  "version": "1.178.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.177.2",
+  "version": "1.178.2",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: Release

**Description**: Reverted PR [#175](https://github.com/microsoft/app-store-vsts-extension/pull/175). Prepared release for 178 sprint.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#171](https://github.com/microsoft/app-store-vsts-extension/issues/171), Resolves [#192](https://github.com/microsoft/app-store-vsts-extension/issues/192) and [#408](https://github.com/microsoft/build-task-team/issues/408)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
