### PR TITLE
[AppStoreRelease] Migrate to node10

### DIFF
--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -20,7 +20,7 @@ describe('app-store-release L0 Suite', function () {
     });
     /* tslint:enable:no-empty */
 
-    it('enforce darwin', (done: MochaDone) => {
+    it('enforce darwin', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0EnforceDarwin.js');
@@ -33,7 +33,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('no authtype', (done: MochaDone) => {
+    it('no authtype', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0NoAuthType.js');
@@ -46,7 +46,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('no service endpoint', (done: MochaDone) => {
+    it('no service endpoint', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0NoEndpoint.js');
@@ -59,7 +59,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('no username+password', (done: MochaDone) => {
+    it('no username+password', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0NoUserPass.js');
@@ -73,7 +73,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('app specific password', (done: MochaDone) => {
+    it('app specific password', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0AppSpecificPassword.js');
@@ -88,7 +88,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('app specific password using service endpoint', (done: MochaDone) => {
+    it('app specific password using service endpoint', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0AppSpecificPasswordEndPoint.js');
@@ -103,7 +103,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('two factor authentication using service endpoint without fastlane session', (done: MochaDone) => {
+    it('two factor authentication using service endpoint without fastlane session', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0AppSpecificPasswordEndPointIncomplete.js');
@@ -115,7 +115,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('two factor authenitcation app specific password without fastlane session', (done: MochaDone) => {
+    it('two factor authenitcation app specific password without fastlane session', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0AppSpecificPasswordNoFastlaneSession.js');
@@ -128,7 +128,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('custom GEM_CACHE env var', (done: MochaDone) => {
+    it('custom GEM_CACHE env var', (done: Mocha.Done) => {
         this.timeout(1000);
 
         //L0GemCacheEnvVar.ts sets the GEM_CACHE env var and expects it to be used when fastlane is updated.
@@ -143,7 +143,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - username+password', (done: MochaDone) => {
+    it('testflight - username+password', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightUserPass.js');
@@ -156,7 +156,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - username+password - no fastlane install', (done: MochaDone) => {
+    it('testflight - username+password - no fastlane install', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightNoFastlaneInstall.js');
@@ -169,7 +169,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - username+password - specific fastlane install', (done: MochaDone) => {
+    it('testflight - username+password - specific fastlane install', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightSpecificFastlaneInstall.js');
@@ -184,7 +184,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - username+password - specific fastlane install - no version', (done: MochaDone) => {
+    it('testflight - username+password - specific fastlane install - no version', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightSpecificFastlaneInstallNoVersion.js');
@@ -197,7 +197,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - service endpoint', (done: MochaDone) => {
+    it('testflight - service endpoint', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightServiceEndpoint.js');
@@ -210,7 +210,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - no ipa path', (done: MochaDone) => {
+    it('testflight - no ipa path', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightNoIpaPath.js');
@@ -223,7 +223,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - team id', (done: MochaDone) => {
+    it('testflight - team id', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightTeamId.js');
@@ -238,7 +238,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - team name', (done: MochaDone) => {
+    it('testflight - team name', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightTeamName.js');
@@ -253,7 +253,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - team id and team name', (done: MochaDone) => {
+    it('testflight - team id and team name', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightTeamIdTeamName.js');
@@ -268,7 +268,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - should skip submission', (done: MochaDone) => {
+    it('testflight - should skip submission', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightShouldSkipSubmission.js');
@@ -283,7 +283,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - should skip waiting for processing', (done: MochaDone) => {
+    it('testflight - should skip waiting for processing', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightShouldSkipWaitingForProcessing.js');
@@ -298,7 +298,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - distribute external no release notes', (done: MochaDone) => {
+    it('testflight - distribute external no release notes', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightDistributeToExternalTestersNoReleaseNotes.js');
@@ -311,7 +311,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - distribute external with groups', (done: MochaDone) => {
+    it('testflight - distribute external with groups', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightDistributeToExternalTestersWithGroups.js');
@@ -323,7 +323,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - one ipa file', (done: MochaDone) => {
+    it('testflight - one ipa file', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightOneIpaFile.js');
@@ -338,7 +338,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - multiple ipa files', (done: MochaDone) => {
+    it('testflight - multiple ipa files', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightMultipleIpaFiles.js');
@@ -352,7 +352,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - zero ipa files', (done: MochaDone) => {
+    it('testflight - zero ipa files', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightZeroIpaFiles.js');
@@ -366,7 +366,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('testflight - additional arguments', (done: MochaDone) => {
+    it('testflight - additional arguments', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0TestFlightFastlaneArguments.js');
@@ -381,7 +381,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - no bundle id', (done: MochaDone) => {
+    it('production - no bundle id', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionNoBundleId.js');
@@ -395,7 +395,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - no ipa path', (done: MochaDone) => {
+    it('production - no ipa path', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionNoIpaPath.js');
@@ -408,7 +408,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - should skip binary upload', (done: MochaDone) => {
+    it('production - should skip binary upload', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionShouldSkipBinaryUpload.js');
@@ -423,7 +423,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - team id', (done: MochaDone) => {
+    it('production - team id', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionTeamId.js');
@@ -438,7 +438,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - team name', (done: MochaDone) => {
+    it('production - team name', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionTeamName.js');
@@ -453,7 +453,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - team id and team name', (done: MochaDone) => {
+    it('production - team id and team name', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionTeamIdTeamName.js');
@@ -468,7 +468,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - should submit for review', (done: MochaDone) => {
+    it('production - should submit for review', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionShouldSubmitForReview.js');
@@ -483,7 +483,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - automatic release', (done: MochaDone) => {
+    it('production - automatic release', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionShouldAutoRelease.js');
@@ -498,7 +498,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - upload metadata with metadata path', (done: MochaDone) => {
+    it('production - upload metadata with metadata path', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionUploadMetadataMetadataPath.js');
@@ -513,7 +513,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - upload screenshots with screenshots path', (done: MochaDone) => {
+    it('production - upload screenshots with screenshots path', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionUploadScreenshotsScreenshotsPath.js');
@@ -528,7 +528,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - one ipa file', (done: MochaDone) => {
+    it('production - one ipa file', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionOneIpaFile.js');
@@ -542,7 +542,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - multiple ipa files', (done: MochaDone) => {
+    it('production - multiple ipa files', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionMultipleIpaFiles.js');
@@ -556,7 +556,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - zero ipa files', (done: MochaDone) => {
+    it('production - zero ipa files', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionZeroIpaFiles.js');
@@ -570,7 +570,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - fastlane arguments', (done: MochaDone) => {
+    it('production - fastlane arguments', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionFastlaneArguments.js');
@@ -584,7 +584,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - macOS app', (done: MochaDone) => {
+    it('production - macOS app', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionMacApp.js');
@@ -599,7 +599,7 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
-    it('production - tvOS app', (done: MochaDone) => {
+    it('production - tvOS app', (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0ProductionTVApp.js');

--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -19,6 +19,7 @@ describe('app-store-release L0 Suite', function () {
     after(() => {
     });
     /* tslint:enable:no-empty */
+    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
     it('enforce darwin', (done: Mocha.Done) => {
         this.timeout(1000);

--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -27,7 +27,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert.equal(true, tr.createdErrorIssue('Error: loc_mock_DarwinOnly'));
+        assert(tr.createdErrorIssue('Error: loc_mock_DarwinOnly'), 'Should have written error message');
         assert(tr.failed, 'task should have failed');
 
         done();

--- a/Tasks/AppStoreRelease/package-lock.json
+++ b/Tasks/AppStoreRelease/package-lock.json
@@ -20,6 +20,11 @@
         "@types/node": "*"
       }
     },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+    },
     "@types/node": {
       "version": "10.17.51",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",

--- a/Tasks/AppStoreRelease/package-lock.json
+++ b/Tasks/AppStoreRelease/package-lock.json
@@ -4,22 +4,53 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "10.17.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+    },
+    "@types/qs": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "azure-pipelines-task-lib": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.11.1.tgz",
-      "integrity": "sha512-y57uWaMWEOCqFommNj1xeyb/76rDSq/l5D0PHTPpK64RdH3fCWs3hAqLETFP//NiI4VZrJxbzS16V/txYpJZoA==",
+      "version": "3.0.6-preview.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.6-preview.1.tgz",
+      "integrity": "sha512-whe4Bk3MwZfcQhO7K3Y6YjPRRacvnM8qswKr+y8LFllEeRojK0QCRXNinw9feMUWwCL6bqc4rDoEJa+5TX95Pg==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",
-        "q": "^1.1.2",
+        "q": "^1.5.1",
         "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "sync-request": "3.0.1",
+        "shelljs": "^0.8.4",
+        "sync-request": "6.1.0",
         "uuid": "^3.0.1"
       }
     },
@@ -43,9 +74,17 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -68,30 +107,120 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "http-basic": {
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "form-data": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
-      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.6",
-        "http-response-object": "^1.0.0"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "http-basic": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+      "requires": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
       }
     },
     "http-response-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
-      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "requires": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "mime-db": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+    },
+    "mime-types": {
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+      "requires": {
+        "mime-db": "1.45.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -106,17 +235,40 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "~2.0.6"
       }
     },
     "q": {
@@ -125,9 +277,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -143,20 +295,42 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "shelljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -167,32 +341,58 @@
       }
     },
     "sync-request": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
-      "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
       "requires": {
-        "concat-stream": "^1.4.7",
-        "http-response-object": "^1.0.1",
-        "then-request": "^2.0.1"
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      }
+    },
+    "sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+      "requires": {
+        "get-port": "^3.1.0"
       }
     },
     "then-request": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
-      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
       "requires": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.7",
-        "http-basic": "^2.5.1",
-        "http-response-object": "^1.1.0",
-        "promise": "^7.1.1",
-        "qs": "^6.1.0"
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+        }
       }
     },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -203,6 +403,11 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/Tasks/AppStoreRelease/package.json
+++ b/Tasks/AppStoreRelease/package.json
@@ -4,6 +4,8 @@
   "description": "Azure Pipelines task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {
+    "@types/node": "^10.17.0",
+    "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.0.6-preview.1"
   },
   "devDependencies": {

--- a/Tasks/AppStoreRelease/package.json
+++ b/Tasks/AppStoreRelease/package.json
@@ -4,9 +4,11 @@
   "description": "Azure Pipelines task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.11.1"
+    "azure-pipelines-task-lib": "^3.0.6-preview.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "4.0.2"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,8 +13,8 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "178",
-        "Patch": "4"
+        "Minor": "182",
+        "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",
@@ -328,7 +328,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node10": {
             "target": "app-store-release.js",
             "argumentFormat": ""
         }

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "182",
+        "Minor": "183",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "182",
+    "Minor": "183",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,8 +15,8 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "178",
-    "Patch": "4"
+    "Minor": "182",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -330,7 +330,7 @@
     }
   ],
   "execution": {
-    "Node": {
+    "Node10": {
       "target": "app-store-release.js",
       "argumentFormat": ""
     }

--- a/make-util.js
+++ b/make-util.js
@@ -167,6 +167,14 @@ var buildNodeTask = function (taskPath, outDir) {
         var tscExec = path.join(overrideTscPath, "bin", "tsc");
         run("node " + tscExec + ' --outDir "' + outDir + '" --rootDir "' + taskPath + '"');
         // Don't include typescript in node_modules
+
+        //remove tsc and tsserver symbolic links
+        if (os.platform !== 'win32') {
+            rm('-f', path.join(taskPath, 'node_modules', '.bin', 'tsc'));
+            rm('-f', path.join(taskPath, 'node_modules', '.bin', 'tsserver'));
+        }
+
+        //remove typescript from node_modules
         rm("-rf", overrideTscPath);
     } else {
         run('tsc --outDir "' + outDir + '" --rootDir "' + taskPath + '"');


### PR DESCRIPTION
**Task name**: AppStoreRelease

**Description**:
- Updated mocha types in tests (MochaDone -> Mocha.Done)
- Added typescript 4.0.2 dev dependency
- Updated tasklib version to 3.0.6-preview.1
- Bumped task version
- Installed @types/mocha and @types/node dependencies
- Fixed deprecated assertion

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/669 (internal)

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected - [successful pipeline](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2447&view=results)
