### PR TITLE
Remove tsc and tsserver Symbolic Links 

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -167,6 +167,14 @@ var buildNodeTask = function (taskPath, outDir) {
         var tscExec = path.join(overrideTscPath, "bin", "tsc");
         run("node " + tscExec + ' --outDir "' + outDir + '" --rootDir "' + taskPath + '"');
         // Don't include typescript in node_modules
+
+        //remove tsc and tsserver symbolic links
+        if (os.platform !== 'win32') {
+            rm('-f', path.join(taskPath, 'node_modules', '.bin', 'tsc'));
+            rm('-f', path.join(taskPath, 'node_modules', '.bin', 'tsserver'));
+        }
+
+        //remove typescript from node_modules
         rm("-rf", overrideTscPath);
     } else {
         run('tsc --outDir "' + outDir + '" --rootDir "' + taskPath + '"');


### PR DESCRIPTION
**Description**: 

[AppStoreExtension.CI](https://dev.azure.com/mseng/AzureDevOps/_build?definitionId=4518&_a=summary) pipeline is failing on `gulp packageprod` while migrating tasks to node10 (on macOs and Ubuntu)


```
Creating PRODUCTION vsix...

[13:49:05] '<anonymous>' errored after 3.28 s
[13:49:05] Error: exited with error code: 255
    at ChildProcess.onexit (/Users/runner/work/1/s/node_modules/end-of-stream/index.js:40:36)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:198:12)
[13:49:05] 'packageprod' errored after 4.61 s
```
---
It looks like the issue came from [vsix-writer](https://github.com/microsoft/tfs-cli/blob/72c0158bfccf9821a5548740c331d057837e3a92/app/exec/extension/_lib/vsix-writer.ts#L186):

error: >>>>>>>>>>>>>>>> Error: ENOENT: no such file or directory, open '/home/max/mz-app-store-vsts-extension/_build/Tasks/AppStorePromote/node_modules/.bin/**tsc'** <<<<<<<<<<<<<
error: >>>>>>>>>>>>>>>> Error: ENOENT: no such file or directory, open '/home/max/mz-app-store-vsts-extension/_build/Tasks/AppStorePromote/node_modules/.bin/**tsserver'** <<<<<<<<<<<<<

---

`tsc` and `tsserver` symbolic links are broken after [removing](https://github.com/microsoft/app-store-vsts-extension/blob/1d98acc3a965e7273fa1dc36134eed39ce1bd63d/make-util.js#L170) typescript

![image](https://user-images.githubusercontent.com/16704239/106608856-f4593c80-6575-11eb-872f-457a4c865f6e.png)

So we decided to remove these symlinks as well as the typescript folder during building a task

---
**Attached related issue:** https://github.com/microsoft/build-task-team/issues/781

**Checklist**:
- [x] Checked that applied changes work as expected
