### PR TITLE
[IpaResign] Fix tests timeout

### DIFF
--- a/Tasks/IpaResign/Tests/L0.ts
+++ b/Tasks/IpaResign/Tests/L0.ts
@@ -19,6 +19,7 @@ describe('ipa-resign L0 Suite', function () {
     after(() => {
     });
     /* tslint:enable:no-empty */
+    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
     it('enforce darwin', (done:MochaDone) => {
         this.timeout(1000);


### PR DESCRIPTION
**Task name**: IpaResign

**Description**: Change test timeout to fix CI failures; because of our node 10 infrastructure changes the CI is trying to download missing Node6 binary in 2 seconds, and thus the pipeline fails.
This will also be useful in case we decide to add unit tests for this task in the future.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** None

**Checklist**:
- [X] Checked that applied changes work as expected:
- [before](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=691&view=results)
- [after](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=692&view=results)
