### PR TITLE
Add restrictions to app store extension tasks

### DIFF
--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -16,7 +16,7 @@
         "Minor": "184",
         "Patch": "0"
     },
-    "minimumAgentVersion": "2.181.1",
+    "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Submit to the App Store for review",
     "groups": [
         {

--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -16,7 +16,7 @@
         "Minor": "184",
         "Patch": "0"
     },
-    "minimumAgentVersion": "1.95.3",
+    "minimumAgentVersion": "2.181.1",
     "instanceNameFormat": "Submit to the App Store for review",
     "groups": [
         {

--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -233,6 +233,14 @@
             "argumentFormat": ""
         }
     },
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": []
+        }
+    },
     "messages": {
         "DarwinOnly": "The Apple App Store Promote task can only run on a Mac computer.",
         "UninstallFastlaneFailed": "There were errors when trying to uninstall fastlane. Review the error and if required add a script to your pipeline to cleanly uninstall fastlane prior to running this task. Uninstall error: %s",

--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "183",
+        "Minor": "184",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "184",
+        "Minor": "186",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "183",
+    "Minor": "184",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -235,6 +235,14 @@
       "argumentFormat": ""
     }
   },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
+    }
+  },
   "messages": {
     "DarwinOnly": "ms-resource:loc.messages.DarwinOnly",
     "UninstallFastlaneFailed": "ms-resource:loc.messages.UninstallFastlaneFailed",

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -18,7 +18,7 @@
     "Minor": "184",
     "Patch": "0"
   },
-  "minimumAgentVersion": "1.95.3",
+  "minimumAgentVersion": "2.181.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -18,7 +18,7 @@
     "Minor": "184",
     "Patch": "0"
   },
-  "minimumAgentVersion": "2.181.1",
+  "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "184",
+    "Minor": "186",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -370,6 +370,14 @@
             "argumentFormat": ""
         }
     },
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": []
+        }
+    },
     "messages": {
         "DarwinOnly": "The Apple App Store Release task can only run on a Mac computer.",
         "UninstallFastlaneFailed": "There were errors when trying to uninstall fastlane. Review the error and if required add a script to your pipeline to cleanly uninstall fastlane prior to running this task. Uninstall error: %s",

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -16,7 +16,7 @@
         "Minor": "184",
         "Patch": "0"
     },
-    "minimumAgentVersion": "1.95.3",
+    "minimumAgentVersion": "2.181.1",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",
     "groups": [
         {

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -16,7 +16,7 @@
         "Minor": "184",
         "Patch": "0"
     },
-    "minimumAgentVersion": "2.181.1",
+    "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",
     "groups": [
         {

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "183",
+        "Minor": "184",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "184",
+        "Minor": "186",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "183",
+    "Minor": "184",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -372,6 +372,14 @@
       "argumentFormat": ""
     }
   },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
+    }
+  },
   "messages": {
     "DarwinOnly": "ms-resource:loc.messages.DarwinOnly",
     "UninstallFastlaneFailed": "ms-resource:loc.messages.UninstallFastlaneFailed",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -18,7 +18,7 @@
     "Minor": "184",
     "Patch": "0"
   },
-  "minimumAgentVersion": "1.95.3",
+  "minimumAgentVersion": "2.181.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -18,7 +18,7 @@
     "Minor": "184",
     "Patch": "0"
   },
-  "minimumAgentVersion": "2.181.1",
+  "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "184",
+    "Minor": "186",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -207,6 +207,14 @@
             "argumentFormat": ""
         }
     },
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": []
+        }
+    },
     "messages": {
         "DarwinOnly": "The Ipa Resign task can only run on a Mac computer.",
         "UninstallFastlaneFailed": "There were errors when trying to uninstall fastlane. Review the error and if required add a script to your pipeline to cleanly uninstall fastlane prior to running this task. Uninstall error: %s",

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -15,7 +15,7 @@
         "Minor": "184",
         "Patch": "0"
     },
-    "minimumAgentVersion": "2.181.1",
+    "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Resign ipa file",
     "groups": [
         {

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -15,7 +15,7 @@
         "Minor": "184",
         "Patch": "0"
     },
-    "minimumAgentVersion": "1.95.3",
+    "minimumAgentVersion": "2.181.1",
     "instanceNameFormat": "Resign ipa file",
     "groups": [
         {

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "184",
+        "Minor": "186",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -12,7 +12,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "183",
+        "Minor": "184",
         "Patch": "0"
     },
     "minimumAgentVersion": "1.95.3",

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -17,7 +17,7 @@
     "Minor": "184",
     "Patch": "0"
   },
-  "minimumAgentVersion": "1.95.3",
+  "minimumAgentVersion": "2.181.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -209,6 +209,14 @@
       "argumentFormat": ""
     }
   },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
+    }
+  },
   "messages": {
     "DarwinOnly": "ms-resource:loc.messages.DarwinOnly",
     "UninstallFastlaneFailed": "ms-resource:loc.messages.UninstallFastlaneFailed",

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -17,7 +17,7 @@
     "Minor": "184",
     "Patch": "0"
   },
-  "minimumAgentVersion": "2.181.1",
+  "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "184",
+    "Minor": "186",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "183",
+    "Minor": "184",
     "Patch": "0"
   },
   "minimumAgentVersion": "1.95.3",


### PR DESCRIPTION
**Task name**: AppStoreRelease, AppStorePromote, IpaResign

**Documentation changes required:** No

**Added unit tests:** No

**Checklist**:
- [x] Checked that applied changes work as expected:

AppStoreRelease:
[service connection basic production no fastlane install](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2702&view=results)
[service connection api key testFlight no fastlane install](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2706&view=results)
[api key auth production](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2707&view=results)
[basic auth testFlight](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2731&view=results)
[skip 2fa](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2709&view=results)

IpaResign:
[using file](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2724&view=results)
[using signing identity](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2726&view=results)

AppStorePromote:
[api key auth](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2727&view=results)
[basic auth](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2728&view=results)
[service connection basic](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2729&view=results)
[service connection api key](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2730&view=results)
