### PR TITLE
Bump extension version to 186

### DIFF
--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.183.1",
+    "version": "1.186.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Azure DevOps build or release pipeline",
     "categories": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.183.1",
+  "version": "1.186.0",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description**: Bumped tasks version to 186 to prepare for the new release

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/974

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected


