### PR TITLE
Fix for wrongly bumped minimum Agent Version

### DIFF
--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -14,9 +14,9 @@
     "version": {
         "Major": "1",
         "Minor": "186",
-        "Patch": "0"
+        "Patch": "1"
     },
-    "minimumAgentVersion": "2.182.1",
+    "minimumAgentVersion": "2.170.1",
     "instanceNameFormat": "Submit to the App Store for review",
     "groups": [
         {

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -16,9 +16,9 @@
   "version": {
     "Major": "1",
     "Minor": "186",
-    "Patch": "0"
+    "Patch": "1"
   },
-  "minimumAgentVersion": "2.182.1",
+  "minimumAgentVersion": "2.170.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -14,9 +14,9 @@
     "version": {
         "Major": "1",
         "Minor": "186",
-        "Patch": "0"
+        "Patch": "1"
     },
-    "minimumAgentVersion": "2.182.1",
+    "minimumAgentVersion": "2.170.1",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",
     "groups": [
         {

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -16,9 +16,9 @@
   "version": {
     "Major": "1",
     "Minor": "186",
-    "Patch": "0"
+    "Patch": "1"
   },
-  "minimumAgentVersion": "2.182.1",
+  "minimumAgentVersion": "2.170.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -13,9 +13,9 @@
     "version": {
         "Major": "1",
         "Minor": "186",
-        "Patch": "0"
+        "Patch": "1"
     },
-    "minimumAgentVersion": "2.182.1",
+    "minimumAgentVersion": "2.170.1",
     "instanceNameFormat": "Resign ipa file",
     "groups": [
         {

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -15,9 +15,9 @@
   "version": {
     "Major": "1",
     "Minor": "186",
-    "Patch": "0"
+    "Patch": "1"
   },
-  "minimumAgentVersion": "2.182.1",
+  "minimumAgentVersion": "2.170.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.186.0",
+    "version": "1.186.1",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Azure DevOps build or release pipeline",
     "categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.186.0",
+  "version": "1.186.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.186.0",
+  "version": "1.186.1",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: Fix for Issue #233 

**Description**: The minimum agent version was bumbed to a version that is not available to on-prem Agents

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
