### PR TITLE
AppStoreRelease task has been updated - '--automatic_release' key will be set to 'true\false' regardless of the shouldAutoRelease parameter

### DIFF
--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -369,7 +369,7 @@ async function run() {
             deliverCommand.argIf(teamId, ['-k', teamId]);
             deliverCommand.argIf(teamName, ['--team_name', teamName]);
             deliverCommand.argIf(shouldSubmitForReview, ['--submit_for_review', 'true']);
-            if(shouldAutoRelease) {
+            if (shouldAutoRelease) {
                 deliverCommand.arg(['--automatic_release', 'true']);
             } else {
                 deliverCommand.arg(['--automatic_release', 'false']);

--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -369,7 +369,11 @@ async function run() {
             deliverCommand.argIf(teamId, ['-k', teamId]);
             deliverCommand.argIf(teamName, ['--team_name', teamName]);
             deliverCommand.argIf(shouldSubmitForReview, ['--submit_for_review', 'true']);
-            deliverCommand.argIf(shouldAutoRelease, ['--automatic_release', 'true']);
+            if(shouldAutoRelease) {
+                deliverCommand.arg(['--automatic_release', 'true']);
+            } else {
+                deliverCommand.arg(['--automatic_release', 'false']);
+            }
 
             if (fastlaneArguments) {
                 deliverCommand.line(fastlaneArguments);

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "186",
+        "Minor": "187",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "186",
+    "Minor": "187",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",


### PR DESCRIPTION
**Task name**: AppStoreRelease

**Description**:  In previous version `--automatic_release` key will be set to 'true only if `shouldAutoRelease` task parameter is present and set to `true`. According to http://docs.fastlane.tools/actions/deliver/#parameters `--automatic_release` has no default value and should be set in any cases. This will be fixed in this PR - `--automatic_release` will be set to `true` or `false`, if `shouldAutoRelease` is present and set to `true` or is absent or set to `false`.

**Documentation changes required:** N

**Added unit tests:** (Y/N) N

**Attached related issue:** https://github.com/microsoft/app-store-vsts-extension/issues/235

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
Links to the test pipelines:
https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=3225&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=f01190a8-b369-4424-8659-b15b918f8f92
https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=3224&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=f20ea864-184b-5603-2ef3-2860f2cce0ec
