### PR TITLE
update the TestFlight (pilot) track to use the appType input to set -m

### DIFF
--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -305,6 +305,24 @@ async function run() {
                 pilotCommand.argIf(externalTestersGroups, ['--groups', externalTestersGroups]);
             }
 
+            //Sets -m depending if app submission is for (ios) iOS, (appletvos) tvOS or (osx) MacOS https://github.com/fastlane/fastlane/blob/326bc64483479107699376280b00aa5f5eef40f8/pilot/lib/pilot/options.rb#L46
+            switch (applicationType.toLocaleLowerCase()) {
+                case 'macos':
+                    pilotCommand.arg(['-m', 'osx']); //Fastlane wants arg as OSX
+                    break;
+
+                case 'ios':
+                    pilotCommand.arg(['-m', 'ios']);
+                    break;
+
+                case 'tvos':
+                    pilotCommand.arg(['-m', 'appletvos']);
+                    break;
+
+                default:
+                    throw new Error(tl.loc('NotValidAppType', applicationType));
+            }
+
             if (fastlaneArguments) {
                 pilotCommand.line(fastlaneArguments);
             }


### PR DESCRIPTION
**Task name**: AppStoreRelease

**Description**: the testflight release track does set the ios type, so the upload will fail for tvos builds. Current workaround is to add it manually using the `fastlaneArguments`.

**Documentation changes required:** (Y) Update documentation to be more tvos friendly. 

**Added unit tests:** (N)

**Attached related issue:** (N)

**Checklist**:
- [ x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [ x] Checked that applied changes work as expected
