### PR TITLE
Updated auto assign action

### DIFF
--- a/.github/workflows/autoAssignABTT.yml
+++ b/.github/workflows/autoAssignABTT.yml
@@ -2,7 +2,7 @@ name: Auto Assign ABTT to Project Board
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.ABTT_TOKEN }}
 
@@ -11,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign to ABTT Project
     steps:
+    - name: "Add triage and area labels"
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: |
+          "Area: AppStore"
+          triage
     - name: "Assign issues with 'Area: ABTT' label to project board"
       uses: srggrs/assign-one-project-github-action@1.2.0
-      if: |
-        contains(github.event.issue.labels.*.name, 'Area: ABTT')
       with:
         project: 'https://github.com/orgs/microsoft/projects/48'
-        column_name: 'Ready for work (prioritised)'
+        column_name: 'Backlog'


### PR DESCRIPTION
**Task name**: N/A (changes for github action)

**Description**: updated auto assign action - to add triage and area labels for new issues, and add automatically to the team board.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it - n/a
- [ ] Checked that applied changes work as expected - n/a
