### PR TITLE
[AppStoreRelease] Fix tests for automatic_release false flag

### DIFF
--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -580,7 +580,7 @@ describe('app-store-release L0 Suite', function () {
             deleteDirectory(tempPath, [keyFileName, '.taskkey']);
         }
 
-        assert(tr.ran(`fastlane deliver --force --precheck_include_in_app_purchases false --api_key_path ${keyFilePath} -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true`), 'fastlane deliver with api key should have been run.');
+        assert(tr.ran(`fastlane deliver --force --precheck_include_in_app_purchases false --api_key_path ${keyFilePath} -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --automatic_release false`), 'fastlane deliver with api key should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane pilot.');
         assert(tr.succeeded, 'task should have succeeded');
 
@@ -627,7 +627,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId --skip_binary_upload true -j ios --skip_metadata true --skip_screenshots true'), 'fastlane deliver with skip_binary_upload should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId --skip_binary_upload true -j ios --skip_metadata true --skip_screenshots true --automatic_release false'), 'fastlane deliver with skip_binary_upload should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -642,7 +642,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId'), 'fastlane deliver with teamId should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --automatic_release false'), 'fastlane deliver with teamId should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -657,7 +657,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --team_name teamName'), 'fastlane deliver with teamName should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --team_name teamName --automatic_release false'), 'fastlane deliver with teamName should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -672,7 +672,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --team_name teamName'), 'fastlane deliver with teamId and teamName should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --team_name teamName --automatic_release false'), 'fastlane deliver with teamId and teamName should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -687,7 +687,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --submit_for_review true'), 'fastlane deliver with submit_for_review should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --submit_for_review true --automatic_release false'), 'fastlane deliver with submit_for_review should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -717,7 +717,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios -m <path> --skip_screenshots true'), 'fastlane deliver with -m should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios -m <path> --skip_screenshots true --automatic_release false'), 'fastlane deliver with -m should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -732,7 +732,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true -w <path>'), 'fastlane deliver with -w should have been run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true -w <path> --automatic_release false'), 'fastlane deliver with -w should have been run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -803,7 +803,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -c mypackage.app -j osx --skip_metadata true --skip_screenshots true --submit_for_review true'), 'fastlane deliver for macOS should have run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -c mypackage.app -j osx --skip_metadata true --skip_screenshots true --submit_for_review true --automatic_release false'), 'fastlane deliver for macOS should have run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
@@ -818,7 +818,7 @@ describe('app-store-release L0 Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j appletvos --skip_metadata true --skip_screenshots true --submit_for_review true'), 'fastlane deliver for tvOS should have run.');
+        assert(tr.ran('fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j appletvos --skip_metadata true --skip_screenshots true --submit_for_review true --automatic_release false'), 'fastlane deliver for tvOS should have run.');
         assert(tr.invokedToolCount === 3, 'should have run gem install, gem update and fastlane deliver.');
         //assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/AppStoreRelease/Tests/L0ProductionApiKey.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionApiKey.ts
@@ -57,7 +57,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force --precheck_include_in_app_purchases false --api_key_path test_temp_path/api_keyD383SF739.json -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true": {
+        "fastlane deliver --force --precheck_include_in_app_purchases false --api_key_path test_temp_path/api_keyD383SF739.json -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionFastlaneArguments.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionFastlaneArguments.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -args someadditioanlargs": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --automatic_release false -args someadditioanlargs": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionMacApp.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionMacApp.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -c mypackage.app -j osx --skip_metadata true --skip_screenshots true --submit_for_review true": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -c mypackage.app -j osx --skip_metadata true --skip_screenshots true --submit_for_review true --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionOneIpaFile.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionOneIpaFile.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionShouldSkipBinaryUpload.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionShouldSkipBinaryUpload.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId --skip_binary_upload true -j ios --skip_metadata true --skip_screenshots true":
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId --skip_binary_upload true -j ios --skip_metadata true --skip_screenshots true --automatic_release false":
         {
             "code": 0,
             "stdout": "consider it delivered!"

--- a/Tasks/AppStoreRelease/Tests/L0ProductionShouldSubmitForReview.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionShouldSubmitForReview.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --submit_for_review true": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --submit_for_review true --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionTVApp.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionTVApp.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j appletvos --skip_metadata true --skip_screenshots true --submit_for_review true": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j appletvos --skip_metadata true --skip_screenshots true --submit_for_review true --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionTeamId.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionTeamId.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionTeamIdTeamName.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionTeamIdTeamName.ts
@@ -55,7 +55,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --team_name teamName": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true -k teamId --team_name teamName --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionTeamName.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionTeamName.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --team_name teamName": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true --skip_screenshots true --team_name teamName --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionUploadMetadataMetadataPath.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionUploadMetadataMetadataPath.ts
@@ -55,7 +55,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios -m <path> --skip_screenshots true": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios -m <path> --skip_screenshots true --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionUploadScreenshotsScreenshotsPath.ts
@@ -55,7 +55,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true -w <path>": {
+        "fastlane deliver --force -u creds-username -a com.microsoft.test.appId -i mypackage.ipa -j ios --skip_metadata true -w <path> --automatic_release false": {
             "code": 0,
             "stdout": "consider it delivered!"
         }


### PR DESCRIPTION
**Task name**: AppStoreRelease

**Description**: Fix tests since they were broken after this [PR](https://github.com/microsoft/app-store-vsts-extension/pull/239)

**Documentation changes required:** N 

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
