### PR TITLE
Bumping up the version from 1.186.0 to 1.188.0

### DIFF
--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.186.0",
+    "version": "1.188.0",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Azure DevOps build or release pipeline",
     "categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.186.0",
+  "version": "1.188.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.186.0",
+  "version": "1.188.0",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The extension version has been bumped up in:
- [app-store-vsts-extension.json](https://github.com/microsoft/app-store-vsts-extension/blob/7492470617bff7742e302441baa2be0c74305978/app-store-vsts-extension.json)
- [package.json](https://github.com/microsoft/app-store-vsts-extension/blob/7492470617bff7742e302441baa2be0c74305978/package.json)
- [package-lock.json](https://github.com/microsoft/app-store-vsts-extension/blob/7492470617bff7742e302441baa2be0c74305978/package-lock.json)

You can check current sprint [here](https://whatsprintis.it/)