### PR TITLE
support macos pkg files for testflight uploads

### DIFF
--- a/Tasks/AppStoreRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppStoreRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -78,8 +78,8 @@
   "loc.messages.DarwinOnly": "The Apple App Store Release task can only run on a Mac computer.",
   "loc.messages.UninstallFastlaneFailed": "There were errors when trying to uninstall fastlane. Review the error and if required add a script to your pipeline to cleanly uninstall fastlane prior to running this task. Uninstall error: %s",
   "loc.messages.SuccessfullyPublished": "Successfully published to %s",
-  "loc.messages.NoIpaFilesFound": "No IPA file found using pattern: %s",
-  "loc.messages.MultipleIpaFilesFound": "More than one IPA file found using pattern: %s",
+  "loc.messages.NoIpaFilesFound": "No IPA/PKG file found using pattern: %s",
+  "loc.messages.MultipleIpaFilesFound": "More than one IPA/PKG file found using pattern: %s",
   "loc.messages.FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
   "loc.messages.ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
   "loc.messages.ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
@@ -87,5 +87,6 @@
   "loc.messages.IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false",
   "loc.messages.SessionAndAppIdNotSet": "Your fastlane session is incorrect and app specific id is not set. Please set correct fastlane session or app specific id",
   "loc.messages.ReleaseNotesRequiresFastlaneSession": "You specified releaseNotes - so you need to provide fastlane session, app specific password only won't work",
-  "loc.messages.PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key."
+  "loc.messages.PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key.",
+  "loc.messages.FastlaneTooOld": "Testflight upload for macOS apps requires fastlane 2.193.1 or newer."
 }

--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -551,6 +551,20 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
+    it('testflight - fastlane too old', (done: Mocha.Done) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, 'L0TestFlightFastlaneTooOld.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.invokedToolCount === 0, 'should not have run any tools.');
+        assert(tr.stdout.indexOf('Error: loc_mock_FastlaneTooOld') !== -1, 'Task should have written to stdout');
+        assert(tr.failed, 'task should have failed');
+
+        done();
+    });
+
     it('production - api key', (done: Mocha.Done) => {
         this.timeout(1000);
 

--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -551,6 +551,18 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
+    it('testflight - fastlane macOS', (done: Mocha.Done) => {
+      this.timeout(1000);
+
+      let tp = path.join(__dirname, 'L0TestFlightFastlaneMacOS.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      tr.run();
+      assert(tr.ran(`fastlane pilot upload -u creds-username -P mypackage.pkg`), 'fastlane pilot upload with pkg file should have been run.');
+
+      done();
+    });
+
     it('testflight - fastlane too old', (done: Mocha.Done) => {
         this.timeout(1000);
 
@@ -559,7 +571,6 @@ describe('app-store-release L0 Suite', function () {
 
         tr.run();
         assert(tr.invokedToolCount === 0, 'should not have run any tools.');
-        assert(tr.stdout.indexOf('Error: loc_mock_FastlaneTooOld') !== -1, 'Task should have written to stdout');
         assert(tr.failed, 'task should have failed');
 
         done();

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneMacOS.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneMacOS.ts
@@ -19,7 +19,7 @@ tmr.setInput('releaseTrack', 'TestFlight');
 tmr.setInput('appType', 'macos');
 tmr.setInput('ipaPath', '**/*.pkg');
 tmr.setInput('fastlaneToolsVersion', 'SpecificVersion');
-tmr.setInput('fastlaneToolsSpecificVersion', '2.193.0');
+tmr.setInput('fastlaneToolsSpecificVersion', '2.193.1');
 
 process.env['HOME'] = '/usr/bin';
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneTooOld.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneTooOld.ts
@@ -1,0 +1,61 @@
+ /*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'app-store-release.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('authType', 'UserAndPass');
+tmr.setInput('username', 'creds-username');
+tmr.setInput('password', 'creds-password');
+tmr.setInput('releaseTrack', 'TestFlight');
+tmr.setInput('appType', 'macos');
+tmr.setInput('fastlaneToolsVersion', 'SpecificVersion');
+tmr.setInput('fastlaneToolsSpecificVersion', '2.193.0');
+
+process.env['HOME'] = '/usr/bin';
+
+// let ipaPath: string = tl.getInput('ipaPath', true);
+//tmr.setInput('ipaPath', '<path>');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    'which': {
+        'ruby': '/usr/bin/ruby',
+        'gem': '/usr/bin/gem',
+        'deliver': '/usr/bin/deliver',
+        'pilot': '/usr/bin/pilot'
+    },
+    'checkPath' : {
+        '/usr/bin/ruby': true,
+        '/usr/bin/gem': true,
+        '/usr/bin/deliver': true,
+        '/usr/bin/pilot': true
+    },
+    'exec': {
+        '/usr/bin/gem install pilot': {
+            'code': 0,
+            'stdout': '10 gems installed'
+        },
+        'pilot upload -u creds-username -i <path>': {
+            'code': 0,
+            'stdout': 'consider it uploaded!'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+// This is how you can mock NPM packages...
+os.platform = () => {
+    return 'darwin';
+};
+tmr.registerMock('os', os);
+
+tmr.run();

--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -172,6 +172,11 @@ async function run() {
         let fastlaneVersionToInstall: string;  //defaults to 'LatestVersion'
         if (fastlaneVersionChoice === 'SpecificVersion') {
             fastlaneVersionToInstall = tl.getInput('fastlaneToolsSpecificVersion', true);
+            if (applicationType.toLocaleLowerCase() === 'macos' &&
+                releaseTrack === 'TestFlight' &&
+                fastlaneVersionToInstall.localeCompare('2.193.0', undefined, { numeric: true }) <= 0 ) {
+                throw new Error(tl.loc('FastlaneTooOld'));
+            }
         }
 
         // Set up environment
@@ -287,7 +292,11 @@ async function run() {
             } else {
                 let bundleIdentifier: string = tl.getInput('appIdentifier', false);
                 pilotCommand.arg(['pilot', 'upload', ...authArgs]);
-                pilotCommand.arg(['-i', filePath]);
+                if (applicationType.toLocaleLowerCase() === 'macos') {
+                    pilotCommand.arg(['-P', filePath]);
+                } else {
+                    pilotCommand.arg(['-i', filePath]);
+                }
                 let usingReleaseNotes: boolean = isValidFilePath(releaseNotes);
                 if (usingReleaseNotes) {
                     if (!credentials.fastlaneSession) {

--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -8,6 +8,7 @@ import fs = require('fs');
 import os = require('os');
 import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
+import semver = require('semver');
 
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 
@@ -174,7 +175,7 @@ async function run() {
             fastlaneVersionToInstall = tl.getInput('fastlaneToolsSpecificVersion', true);
             if (applicationType.toLocaleLowerCase() === 'macos' &&
                 releaseTrack === 'TestFlight' &&
-                fastlaneVersionToInstall.localeCompare('2.193.0', undefined, { numeric: true }) <= 0 ) {
+                semver.lte(fastlaneVersionToInstall, '2.193.0')) {
                 throw new Error(tl.loc('FastlaneTooOld'));
             }
         }

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "207",
+        "Minor": "211",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -416,6 +416,7 @@
         "IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false",
         "SessionAndAppIdNotSet": "Your fastlane session is incorrect and app specific id is not set. Please set correct fastlane session or app specific id",
         "ReleaseNotesRequiresFastlaneSession": "You specified releaseNotes - so you need to provide fastlane session, app specific password only won't work",
-        "PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key."
+        "PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key.",
+        "FastlaneTooOld": "Testflight upload for macOS apps requires fastlane 2.193.1 or newer."
     }
 }

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "207",
+    "Minor": "211",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -418,6 +418,7 @@
     "IpaPathNotSpecified": "ms-resource:loc.messages.IpaPathNotSpecified",
     "SessionAndAppIdNotSet": "ms-resource:loc.messages.SessionAndAppIdNotSet",
     "ReleaseNotesRequiresFastlaneSession": "ms-resource:loc.messages.ReleaseNotesRequiresFastlaneSession",
-    "PrecheckInAppPurchasesDisabled": "ms-resource:loc.messages.PrecheckInAppPurchasesDisabled"
+    "PrecheckInAppPurchasesDisabled": "ms-resource:loc.messages.PrecheckInAppPurchasesDisabled",
+    "FastlaneTooOld": "ms-resource:loc.messages.FastlaneTooOld"
   }
 }


### PR DESCRIPTION
**Task name**: AppStoreRelease

**Description**: Added support for Testflight uploads for macOS pkg files as Apple is now offering Testflight for macOS, too

**Documentation changes required:** Y

**Added unit tests:** Y (added test case for fastlane version check. Testflight for macOS requires 2.193.1 or newer)

**Attached related issue:** 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
