### PR TITLE
Change sample tokens to dummy strings

### DIFF
--- a/Tasks/AppStorePromote/Tests/L0.ts
+++ b/Tasks/AppStorePromote/Tests/L0.ts
@@ -166,7 +166,7 @@ describe('app-store-promote L0 Suite', function () {
 
         assert(apiKey.key_id === 'D383SF739', 'key_id should be correct');
         assert(apiKey.issuer_id === '6053b7fe-68a8-4acb-89be-165aa6465141', 'issuer_id should be correct');
-        assert(apiKey.key === 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t', 'key should be correct');
+        assert(apiKey.key === 'dummy_string', 'key should be correct');
         assert(apiKey.in_house === false, 'in_house should be correct');
         assert(apiKey.is_key_content_base64 === true, 'is_key_content_base64 should be correct');
 
@@ -208,7 +208,7 @@ describe('app-store-promote L0 Suite', function () {
 
         assert(apiKey.key_id === 'D383SF739', 'key_id should be correct');
         assert(apiKey.issuer_id === '6053b7fe-68a8-4acb-89be-165aa6465141', 'issuer_id should be correct');
-        assert(apiKey.key === 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t', 'key should be correct');
+        assert(apiKey.key === 'dummy_string', 'key should be correct');
         assert(apiKey.in_house === false, 'in_house should be correct');
         assert(apiKey.is_key_content_base64 === true, 'is_key_content_base64 should be correct');
 

--- a/Tasks/AppStorePromote/Tests/L0ApiKeyDeliver.ts
+++ b/Tasks/AppStorePromote/Tests/L0ApiKeyDeliver.ts
@@ -15,7 +15,7 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tmr.setInput('authType', 'ApiKey');
 tmr.setInput('apiKeyId', 'D383SF739');
 tmr.setInput('apiKeyIssuerId', '6053b7fe-68a8-4acb-89be-165aa6465141');
-tmr.setInput('apitoken', 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t');
+tmr.setInput('apitoken', 'dummy_string');
 tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 tmr.setInput('chooseBuild', 'latest');
 tmr.setInput('shouldAutoRelease', 'true');

--- a/Tasks/AppStorePromote/Tests/L0ApiKeyEndPoint.ts
+++ b/Tasks/AppStorePromote/Tests/L0ApiKeyEndPoint.ts
@@ -12,7 +12,7 @@ import os = require('os');
 let taskPath = path.join(__dirname, '..', 'app-store-promote.js');
 let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_MyServiceEndpoint'] = '{ "parameters": {"apiKeyId": "D383SF739", "apiKeyIssuerId": "6053b7fe-68a8-4acb-89be-165aa6465141", "apitoken": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t" }, "scheme": "Token" }';
+process.env['ENDPOINT_AUTH_MyServiceEndpoint'] = '{ "parameters": {"apiKeyId": "D383SF739", "apiKeyIssuerId": "6053b7fe-68a8-4acb-89be-165aa6465141", "apitoken": "dummy_string" }, "scheme": "Token" }';
 
 tmr.setInput('authType', 'ServiceEndpoint');
 tmr.setInput('serviceEndpoint', 'MyServiceEndpoint');

--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -179,7 +179,7 @@ describe('app-store-release L0 Suite', function () {
 
         assert(apiKey.key_id === 'D383SF739', 'key_id should be correct');
         assert(apiKey.issuer_id === '6053b7fe-68a8-4acb-89be-165aa6465141', 'issuer_id should be correct');
-        assert(apiKey.key === 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t', 'key should be correct');
+        assert(apiKey.key === 'dummy_string', 'key should be correct');
         assert(apiKey.in_house === false, 'in_house should be correct');
         assert(apiKey.is_key_content_base64 === true, 'is_key_content_base64 should be correct');
 
@@ -277,7 +277,7 @@ describe('app-store-release L0 Suite', function () {
 
         assert(apiKey.key_id === 'D383SF739', 'key_id should be correct');
         assert(apiKey.issuer_id === '6053b7fe-68a8-4acb-89be-165aa6465141', 'issuer_id should be correct');
-        assert(apiKey.key === 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t', 'key should be correct');
+        assert(apiKey.key === 'dummy_string', 'key should be correct');
         assert(apiKey.in_house === false, 'in_house should be correct');
         assert(apiKey.is_key_content_base64 === true, 'is_key_content_base64 should be correct');
 
@@ -319,7 +319,7 @@ describe('app-store-release L0 Suite', function () {
 
         assert(apiKey.key_id === 'D383SF739', 'key_id should be correct');
         assert(apiKey.issuer_id === '6053b7fe-68a8-4acb-89be-165aa6465141', 'issuer_id should be correct');
-        assert(apiKey.key === 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t', 'key should be correct');
+        assert(apiKey.key === 'dummy_string', 'key should be correct');
         assert(apiKey.in_house === false, 'in_house should be correct');
         assert(apiKey.is_key_content_base64 === true, 'is_key_content_base64 should be correct');
 
@@ -586,7 +586,7 @@ describe('app-store-release L0 Suite', function () {
 
         assert(apiKey.key_id === 'D383SF739', 'key_id should be correct');
         assert(apiKey.issuer_id === '6053b7fe-68a8-4acb-89be-165aa6465141', 'issuer_id should be correct');
-        assert(apiKey.key === 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t', 'key should be correct');
+        assert(apiKey.key === 'dummy_string', 'key should be correct');
         assert(apiKey.in_house === false, 'in_house should be correct');
         assert(apiKey.is_key_content_base64 === true, 'is_key_content_base64 should be correct');
 

--- a/Tasks/AppStoreRelease/Tests/L0ApiKeyEndPoint.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ApiKeyEndPoint.ts
@@ -12,7 +12,7 @@ import os = require('os');
 let taskPath = path.join(__dirname, '..', 'app-store-release.js');
 let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env['ENDPOINT_AUTH_MyServiceEndpoint'] = '{ "parameters": {"apiKeyId": "D383SF739", "apiKeyIssuerId": "6053b7fe-68a8-4acb-89be-165aa6465141", "apitoken": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t" }, "scheme": "Token" }';
+process.env['ENDPOINT_AUTH_MyServiceEndpoint'] = '{ "parameters": {"apiKeyId": "D383SF739", "apiKeyIssuerId": "6053b7fe-68a8-4acb-89be-165aa6465141", "apitoken": "dummy_string" }, "scheme": "Token" }';
 
 tmr.setInput('authType', 'ServiceEndpoint');
 tmr.setInput('serviceEndpoint', 'MyServiceEndpoint');

--- a/Tasks/AppStoreRelease/Tests/L0ProductionApiKey.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ProductionApiKey.ts
@@ -15,7 +15,7 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tmr.setInput('authType', 'ApiKey');
 tmr.setInput('apiKeyId', 'D383SF739');
 tmr.setInput('apiKeyIssuerId', '6053b7fe-68a8-4acb-89be-165aa6465141');
-tmr.setInput('apitoken', 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t');
+tmr.setInput('apitoken', 'dummy_string');
 tmr.setInput('appIdentifier', 'com.microsoft.test.appId');
 tmr.setInput('releaseTrack', 'Production');
 tmr.setInput('installFastlane', 'true');

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightApiKey.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightApiKey.ts
@@ -15,7 +15,7 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tmr.setInput('authType', 'ApiKey');
 tmr.setInput('apiKeyId', 'D383SF739');
 tmr.setInput('apiKeyIssuerId', '6053b7fe-68a8-4acb-89be-165aa6465141');
-tmr.setInput('apitoken', 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t');
+tmr.setInput('apitoken', 'dummy_string');
 tmr.setInput('releaseTrack', 'TestFlight');
 tmr.setInput('appType', 'iOS');
 tmr.setInput('ipaPath', 'mypackage.ipa');

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightApiKeyDistributeOnly.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightApiKeyDistributeOnly.ts
@@ -15,7 +15,7 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tmr.setInput('authType', 'ApiKey');
 tmr.setInput('apiKeyId', 'D383SF739');
 tmr.setInput('apiKeyIssuerId', '6053b7fe-68a8-4acb-89be-165aa6465141');
-tmr.setInput('apitoken', 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR1RBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJIa25saGRsWWRMdQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t');
+tmr.setInput('apitoken', 'dummy_string');
 tmr.setInput('releaseTrack', 'TestFlight');
 tmr.setInput('appType', 'iOS');
 tmr.setInput('ipaPath', 'mypackage.ipa');


### PR DESCRIPTION
**Task name**: Changes only in L0 Tests

**Description**: Changed api keys and tokens to dummy strings so that they won't be considered as exposed secrets

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/app-store-vsts-extension/issues/288

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it - _No changes in tasks, not needed_
- [x] Checked that applied changes work as expected
