### PR TITLE
Fix warning message for release notes require 2FA (FS or API Key)

### DIFF
--- a/Tasks/AppStoreRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppStoreRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -86,6 +86,6 @@
   "loc.messages.NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
   "loc.messages.IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false",
   "loc.messages.SessionAndAppIdNotSet": "Your fastlane session is incorrect and app specific id is not set. Please set correct fastlane session or app specific id",
-  "loc.messages.ReleaseNotesRequiresFastlaneSession": "You specified releaseNotes - so you need to provide fastlane session, app specific password only won't work",
+  "loc.messages.ReleaseNotesRequiresApiKeyOrFS": "You specified releaseNotes - so you need to provide API Key or fastlane session, app specific password only won't work",
   "loc.messages.PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key."
 }

--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -290,8 +290,8 @@ async function run() {
                 pilotCommand.arg(['-i', filePath]);
                 let usingReleaseNotes: boolean = isValidFilePath(releaseNotes);
                 if (usingReleaseNotes) {
-                    if (!credentials.fastlaneSession) {
-                        tl.warning(tl.loc('ReleaseNotesRequiresFastlaneSession'));
+                    if (!credentials.fastlaneSession && !isUsingApiKey) {
+                        tl.warning(tl.loc('ReleaseNotesRequiresApiKeyOrFS'));
                     }
 
                     pilotCommand.arg(['--changelog', fs.readFileSync(releaseNotes).toString()]);

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "207",
+        "Minor": "214",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -415,7 +415,7 @@
         "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
         "IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false",
         "SessionAndAppIdNotSet": "Your fastlane session is incorrect and app specific id is not set. Please set correct fastlane session or app specific id",
-        "ReleaseNotesRequiresFastlaneSession": "You specified releaseNotes - so you need to provide fastlane session, app specific password only won't work",
+        "ReleaseNotesRequiresApiKeyOrFS": "You specified releaseNotes - so you need to provide API Key or fastlane session, app specific password only won't work",
         "PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key."
     }
 }

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "207",
+    "Minor": "214",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",
@@ -417,7 +417,7 @@
     "NotValidAppType": "ms-resource:loc.messages.NotValidAppType",
     "IpaPathNotSpecified": "ms-resource:loc.messages.IpaPathNotSpecified",
     "SessionAndAppIdNotSet": "ms-resource:loc.messages.SessionAndAppIdNotSet",
-    "ReleaseNotesRequiresFastlaneSession": "ms-resource:loc.messages.ReleaseNotesRequiresFastlaneSession",
+    "ReleaseNotesRequiresApiKeyOrFS": "ms-resource:loc.messages.ReleaseNotesRequiresApiKeyOrFS",
     "PrecheckInAppPurchasesDisabled": "ms-resource:loc.messages.PrecheckInAppPurchasesDisabled"
   }
 }


### PR DESCRIPTION
**Task name**: AppStoreRelease@1

**Description**: Changed the warning message for 2FA which is needed for Release Notes Uploading. In the past only Fastlane Session was possible. But now it is also possible to use API Key. Therefore, updated the condition and warning message.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/app-store-vsts-extension/issues/289

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
