### PR TITLE
[AppStoreRelease] Support macos pkg files for testflight uploads 

### DIFF
--- a/Tasks/AppStoreRelease/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppStoreRelease/Strings/resources.resjson/en-US/resources.resjson
@@ -78,14 +78,15 @@
   "loc.messages.DarwinOnly": "The Apple App Store Release task can only run on a Mac computer.",
   "loc.messages.UninstallFastlaneFailed": "There were errors when trying to uninstall fastlane. Review the error and if required add a script to your pipeline to cleanly uninstall fastlane prior to running this task. Uninstall error: %s",
   "loc.messages.SuccessfullyPublished": "Successfully published to %s",
-  "loc.messages.NoIpaFilesFound": "No IPA file found using pattern: %s",
-  "loc.messages.MultipleIpaFilesFound": "More than one IPA file found using pattern: %s",
+  "loc.messages.NoIpaFilesFound": "No IPA/PKG file found using pattern: %s",
+  "loc.messages.MultipleIpaFilesFound": "More than one IPA/PKG file found using pattern: %s",
   "loc.messages.FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
   "loc.messages.ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
   "loc.messages.ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",
   "loc.messages.NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
   "loc.messages.IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false",
   "loc.messages.SessionAndAppIdNotSet": "Your fastlane session is incorrect and app specific id is not set. Please set correct fastlane session or app specific id",
-  "loc.messages.ReleaseNotesRequiresApiKeyOrFS": "You specified releaseNotes - so you need to provide API Key or fastlane session, app specific password only won't work",
-  "loc.messages.PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key."
+  "loc.messages.ReleaseNotesRequiresFastlaneSession": "You specified releaseNotes - so you need to provide fastlane session, app specific password only won't work",
+  "loc.messages.PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key.",
+  "loc.messages.FastlaneTooOld": "Testflight upload for macOS apps requires fastlane 2.193.1 or newer."
 }

--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -551,6 +551,31 @@ describe('app-store-release L0 Suite', function () {
         done();
     });
 
+    it('testflight - fastlane macOS', (done: Mocha.Done) => {
+      this.timeout(1000);
+
+      let tp = path.join(__dirname, 'L0TestFlightFastlaneMacOS.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      tr.run();
+      assert(tr.ran(`fastlane pilot upload -u creds-username -P mypackage.pkg`), 'fastlane pilot upload with pkg file should have been run.');
+
+      done();
+    });
+
+    it('testflight - fastlane too old', (done: Mocha.Done) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, 'L0TestFlightFastlaneTooOld.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.invokedToolCount === 0, 'should not have run any tools.');
+        assert(tr.failed, 'task should have failed');
+
+        done();
+    });
+
     it('production - api key', (done: Mocha.Done) => {
         this.timeout(1000);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneMacOS.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneMacOS.ts
@@ -1,0 +1,67 @@
+ /*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'app-store-release.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('authType', 'UserAndPass');
+tmr.setInput('username', 'creds-username');
+tmr.setInput('password', 'creds-password');
+tmr.setInput('releaseTrack', 'TestFlight');
+tmr.setInput('appType', 'macos');
+tmr.setInput('ipaPath', '**/*.pkg');
+tmr.setInput('fastlaneToolsVersion', 'SpecificVersion');
+tmr.setInput('fastlaneToolsSpecificVersion', '2.193.1');
+
+process.env['HOME'] = '/usr/bin';
+
+// let ipaPath: string = tl.getInput('ipaPath', true);
+//tmr.setInput('ipaPath', '<path>');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    'which': {
+        'ruby': '/usr/bin/ruby',
+        'gem': '/usr/bin/gem',
+        'deliver': '/usr/bin/deliver',
+        'pilot': '/usr/bin/pilot'
+    },
+    'checkPath' : {
+        '/usr/bin/ruby': true,
+        '/usr/bin/gem': true,
+        '/usr/bin/deliver': true,
+        '/usr/bin/pilot': true
+    },
+    'findMatch': {
+      '**/*.pkg': [
+          'mypackage.pkg'
+      ]
+    },
+    'exec': {
+        '/usr/bin/gem install pilot': {
+            'code': 0,
+            'stdout': '10 gems installed'
+        },
+        'pilot upload -u creds-username -P mypackage.pkg': {
+            'code': 0,
+            'stdout': 'consider it uploaded!'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+// This is how you can mock NPM packages...
+os.platform = () => {
+    return 'darwin';
+};
+tmr.registerMock('os', os);
+
+tmr.run();

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneTooOld.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneTooOld.ts
@@ -1,0 +1,67 @@
+ /*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'app-store-release.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('authType', 'UserAndPass');
+tmr.setInput('username', 'creds-username');
+tmr.setInput('password', 'creds-password');
+tmr.setInput('releaseTrack', 'TestFlight');
+tmr.setInput('appType', 'macos');
+tmr.setInput('ipaPath', '**/*.pkg');
+tmr.setInput('fastlaneToolsVersion', 'SpecificVersion');
+tmr.setInput('fastlaneToolsSpecificVersion', '2.193.0');
+
+process.env['HOME'] = '/usr/bin';
+
+// let ipaPath: string = tl.getInput('ipaPath', true);
+//tmr.setInput('ipaPath', '<path>');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    'which': {
+        'ruby': '/usr/bin/ruby',
+        'gem': '/usr/bin/gem',
+        'deliver': '/usr/bin/deliver',
+        'pilot': '/usr/bin/pilot'
+    },
+    'checkPath' : {
+        '/usr/bin/ruby': true,
+        '/usr/bin/gem': true,
+        '/usr/bin/deliver': true,
+        '/usr/bin/pilot': true
+    },
+    'findMatch': {
+      '**/*.pkg': [
+          'mypackage.pkg'
+      ]
+    },
+    'exec': {
+        '/usr/bin/gem install pilot': {
+            'code': 0,
+            'stdout': '10 gems installed'
+        },
+        'pilot upload -u creds-username -P mypackage.pkg': {
+            'code': 0,
+            'stdout': 'consider it uploaded!'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+// This is how you can mock NPM packages...
+os.platform = () => {
+    return 'darwin';
+};
+tmr.registerMock('os', os);
+
+tmr.run();

--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -8,6 +8,7 @@ import fs = require('fs');
 import os = require('os');
 import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
+import semver = require('semver');
 
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 
@@ -172,6 +173,11 @@ async function run() {
         let fastlaneVersionToInstall: string;  //defaults to 'LatestVersion'
         if (fastlaneVersionChoice === 'SpecificVersion') {
             fastlaneVersionToInstall = tl.getInput('fastlaneToolsSpecificVersion', true);
+            if (applicationType.toLocaleLowerCase() === 'macos' &&
+                releaseTrack === 'TestFlight' &&
+                semver.lte(fastlaneVersionToInstall, '2.193.0')) {
+                throw new Error(tl.loc('FastlaneTooOld'));
+            }
         }
 
         // Set up environment
@@ -287,7 +293,11 @@ async function run() {
             } else {
                 let bundleIdentifier: string = tl.getInput('appIdentifier', false);
                 pilotCommand.arg(['pilot', 'upload', ...authArgs]);
-                pilotCommand.arg(['-i', filePath]);
+                if (applicationType.toLocaleLowerCase() === 'macos') {
+                    pilotCommand.arg(['-P', filePath]);
+                } else {
+                    pilotCommand.arg(['-i', filePath]);
+                }
                 let usingReleaseNotes: boolean = isValidFilePath(releaseNotes);
                 if (usingReleaseNotes) {
                     if (!credentials.fastlaneSession && !isUsingApiKey) {

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -415,7 +415,8 @@
         "NotValidAppType": "An incorrect ApplicationType was chosen. Valid values iOS, macOS or tvOS. Value set: %s",
         "IpaPathNotSpecified": "You need to specify ipaPath - since skipBinaryUpload = false",
         "SessionAndAppIdNotSet": "Your fastlane session is incorrect and app specific id is not set. Please set correct fastlane session or app specific id",
-        "ReleaseNotesRequiresApiKeyOrFS": "You specified releaseNotes - so you need to provide API Key or fastlane session, app specific password only won't work",
-        "PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key."
+        "ReleaseNotesRequiresFastlaneSession": "You specified releaseNotes - so you need to provide fastlane session, app specific password only won't work",
+        "PrecheckInAppPurchasesDisabled": "Precheck will not check In-app purchases because Fastlane doesn't support it with the App Store Connect API Key.",
+        "FastlaneTooOld": "Testflight upload for macOS apps requires fastlane 2.193.1 or newer."
     }
 }

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -13,7 +13,7 @@
     "demands": [ "xcode" ],
     "version": {
         "Major": "1",
-        "Minor": "214",
+        "Minor": "216",
         "Patch": "0"
     },
     "minimumAgentVersion": "2.182.1",
@@ -407,8 +407,8 @@
         "DarwinOnly": "The Apple App Store Release task can only run on a Mac computer.",
         "UninstallFastlaneFailed": "There were errors when trying to uninstall fastlane. Review the error and if required add a script to your pipeline to cleanly uninstall fastlane prior to running this task. Uninstall error: %s",
         "SuccessfullyPublished": "Successfully published to %s",
-        "NoIpaFilesFound": "No IPA file found using pattern: %s",
-        "MultipleIpaFilesFound": "More than one IPA file found using pattern: %s",
+        "NoIpaFilesFound": "No IPA/PKG file found using pattern: %s",
+        "MultipleIpaFilesFound": "More than one IPA/PKG file found using pattern: %s",
         "FastlaneSessionEmpty": "'Fastlane Session' is not set in the service connection configured for two-step verification.",
         "ReleaseNotesRequiredForExternalTesting": "'What to Test?' is required when using 'Distribute to External Testers'.",
         "ExternalTestersCannotSkipWarning": "'Skip Build Processing Wait' and 'Skip Submission' is not supported with 'Distribute to External Testers'. Please check your build configuration.",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": "1",
-    "Minor": "214",
+    "Minor": "216",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -417,7 +417,8 @@
     "NotValidAppType": "ms-resource:loc.messages.NotValidAppType",
     "IpaPathNotSpecified": "ms-resource:loc.messages.IpaPathNotSpecified",
     "SessionAndAppIdNotSet": "ms-resource:loc.messages.SessionAndAppIdNotSet",
-    "ReleaseNotesRequiresApiKeyOrFS": "ms-resource:loc.messages.ReleaseNotesRequiresApiKeyOrFS",
-    "PrecheckInAppPurchasesDisabled": "ms-resource:loc.messages.PrecheckInAppPurchasesDisabled"
+    "ReleaseNotesRequiresFastlaneSession": "ms-resource:loc.messages.ReleaseNotesRequiresFastlaneSession",
+    "PrecheckInAppPurchasesDisabled": "ms-resource:loc.messages.PrecheckInAppPurchasesDisabled",
+    "FastlaneTooOld": "ms-resource:loc.messages.FastlaneTooOld"
   }
 }


### PR DESCRIPTION
**Task name**: AppStoreRelease

**Description**: This PR is based on https://github.com/microsoft/app-store-vsts-extension/pull/257, it simply resolves the current conflicts and updates the task version to the current sprint. For more details please check the original PR.

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
