### PR TITLE
Fix typo in YAML template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,10 +22,10 @@ steps:
 - script: node make.js test
   displayName: 'Run Tests'
 
-- script: node make.js packageprod
+- script: node make.js createtest
   displayName: 'Build test package'
 
-- script: node make.js packagetest
+- script: node make.js create
   displayName: 'Build prod package'
 
 - task: CopyFiles@2

--- a/make.js
+++ b/make.js
@@ -313,7 +313,7 @@ target.test = function() {
     }
 }
 
-target.packageprod = function() {
+target.create = function() {
     banner('Creating PRODUCTION vsix...');
 
     var prodManifestOverride = {
@@ -323,7 +323,7 @@ target.packageprod = function() {
     createExtension(prodManifestOverride);
 }
 
-target.packagetest = function() {
+target.createtest = function() {
     banner('Creating TEST vsix...');
 
     var devManifestOverride = {


### PR DESCRIPTION
**Description**: This PR fixes typos in YAML template when the `prod` extension was created in `dev` creation stage and `dev` extension was created in `prod` creation stage, it also updates make command to accord with https://github.com/microsoft/google-play-vsts-extension

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Checked that applied changes work as expected
