### PR TITLE
Update types/node

### DIFF
--- a/Tasks/AppStorePromote/package-lock.json
+++ b/Tasks/AppStorePromote/package-lock.json
@@ -26,9 +26,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "10.17.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
-      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+      "version": "16.18.69",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.69.tgz",
+      "integrity": "sha512-AfDKv5fWd9XStaEuqFa6PYcM8FgTqxVMsP4BPk60emeB9YX+pp2P0zZ8nU1BQg8hyPGFrMt7MGMRMis8IrcPyg=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -214,6 +214,13 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
       }
     },
     "inflight": {

--- a/Tasks/AppStorePromote/package.json
+++ b/Tasks/AppStorePromote/package.json
@@ -5,7 +5,7 @@
   "main": "app-store-promote.js",
   "dependencies": {
     "azure-pipelines-task-lib": "^4.2.0",
-    "@types/node": "^10.17.0",
+    "@types/node": "^16.11.39",
     "@types/mocha": "^5.2.7"
   },
   "devDependencies": {

--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "233",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Submit to the App Store for review",

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "233",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AppStoreRelease/package-lock.json
+++ b/Tasks/AppStoreRelease/package-lock.json
@@ -26,9 +26,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "10.17.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
-      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+      "version": "16.18.69",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.69.tgz",
+      "integrity": "sha512-AfDKv5fWd9XStaEuqFa6PYcM8FgTqxVMsP4BPk60emeB9YX+pp2P0zZ8nU1BQg8hyPGFrMt7MGMRMis8IrcPyg=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -214,6 +214,13 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
       }
     },
     "inflight": {

--- a/Tasks/AppStoreRelease/package.json
+++ b/Tasks/AppStoreRelease/package.json
@@ -4,7 +4,7 @@
   "description": "Azure Pipelines task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {
-    "@types/node": "^10.17.0",
+    "@types/node": "^16.11.39",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^4.2.0"
   },

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "233",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "233",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/IpaResign/package-lock.json
+++ b/Tasks/IpaResign/package-lock.json
@@ -26,9 +26,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "10.17.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
-      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+      "version": "16.18.69",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.69.tgz",
+      "integrity": "sha512-AfDKv5fWd9XStaEuqFa6PYcM8FgTqxVMsP4BPk60emeB9YX+pp2P0zZ8nU1BQg8hyPGFrMt7MGMRMis8IrcPyg=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -214,6 +214,13 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
       }
     },
     "inflight": {

--- a/Tasks/IpaResign/package.json
+++ b/Tasks/IpaResign/package.json
@@ -5,7 +5,7 @@
   "main": "ipa-resign.js",
   "dependencies": {
     "azure-pipelines-task-lib": "^4.2.0",
-    "@types/node": "^10.17.0",
+    "@types/node": "^16.11.39",
     "@types/mocha": "^5.2.7"
   },
   "devDependencies": {

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": "1",
         "Minor": "233",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Resign ipa file",

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "1",
     "Minor": "233",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Bump @types/node up to 16.11.39 according to docs:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode16.md#upgrading-tasks-to-node-16

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
