### PR TITLE
Fix issue #361: Install fastlane gem using --no-document

### DIFF
--- a/Tasks/AppStorePromote/app-store-promote.ts
+++ b/Tasks/AppStorePromote/app-store-promote.ts
@@ -182,7 +182,7 @@ async function run() {
         if (installFastlane) {
             tl.debug('Installing fastlane...');
             let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
-            gemRunner.arg(['install', 'fastlane']);
+            gemRunner.arg(['install', '--no-document', 'fastlane']);
             if (fastlaneVersionToInstall) {
                 tl.debug(`Installing specific version of fastlane: ${fastlaneVersionToInstall}`);
                 gemRunner.arg(['-v', fastlaneVersionToInstall]);

--- a/Tasks/AppStoreRelease/app-store-release.ts
+++ b/Tasks/AppStoreRelease/app-store-release.ts
@@ -244,7 +244,7 @@ async function run() {
         if (installFastlane) {
             tl.debug('Installing fastlane...');
             let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
-            gemRunner.arg(['install', 'fastlane']);
+            gemRunner.arg(['install', '--no-document', 'fastlane']);
             if (fastlaneVersionToInstall) {
                 tl.debug(`Installing specific version of fastlane: ${fastlaneVersionToInstall}`);
                 gemRunner.arg(['-v', fastlaneVersionToInstall]);

--- a/Tasks/IpaResign/ipa-resign.ts
+++ b/Tasks/IpaResign/ipa-resign.ts
@@ -169,7 +169,7 @@ async function run() {
         if (installFastlane) {
             tl.debug('Installing fastlane...');
             let gemRunner: ToolRunner = tl.tool(tl.which('gem', true));
-            gemRunner.arg(['install', 'fastlane']);
+            gemRunner.arg(['install', '--no-document', 'fastlane']);
             if (fastlaneVersionToInstall) {
                 tl.debug(`Installing specific version of fastlane: ${fastlaneVersionToInstall}`);
                 gemRunner.arg(['-v', fastlaneVersionToInstall]);


### PR DESCRIPTION
**Task name**: IpaResign, AppStorePromote, AppStoreRelease

**Description**:
Save 21 seconds per run by skipping RI documentation.
- Added `--no-document` to fastlane install in task IpaResign.
- Added `--no-document` to fastlane install in task AppStorePromote.
- Added `--no-document` to fastlane install in task AppStoreRelease.


**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** #361 

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
