### PR TITLE
Fix app type missing on test flight release

### DIFF
--- a/Tasks/AppStorePromote/Tests/L0GemCacheEnvVar.ts
+++ b/Tasks/AppStorePromote/Tests/L0GemCacheEnvVar.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');

--- a/Tasks/AppStoreRelease/Tests/L0.ts
+++ b/Tasks/AppStoreRelease/Tests/L0.ts
@@ -7,16 +7,16 @@
 // npm install mocha --save-dev
 // typings install dt~mocha --save --global
 
-import * as fs from 'fs';
-import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe('app-store-release L0 Suite', function () {
   /* tslint:disable:no-empty */
-  before(() => {});
+  before(() => { });
 
-  after(() => {});
+  after(() => { });
   /* tslint:enable:no-empty */
   this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
@@ -181,7 +181,7 @@ describe('app-store-release L0 Suite', function () {
     }
 
     assert(
-      tr.ran(`fastlane pilot upload --api_key_path ${keyFilePath} -i mypackage.ipa`),
+      tr.ran(`fastlane pilot upload --api_key_path ${keyFilePath} -i mypackage.ipa -j ios`),
       'fastlane pilot upload with api key should have been run.'
     );
     assert(tr.invokedToolCount === 1, 'should have run only fastlane pilot.');
@@ -255,7 +255,7 @@ describe('app-store-release L0 Suite', function () {
     );
     assert(
       tr.ran(
-        'fastlane pilot distribute -u creds-username --build_number 100 -a com.microsoft.test.appId --groups Beta'
+        'fastlane pilot distribute -u creds-username --build_number 100 -a com.microsoft.test.appId -j ios --groups Beta'
       ),
       'fastlane pilot distribute with build_number should have been run.'
     );
@@ -292,7 +292,7 @@ describe('app-store-release L0 Suite', function () {
     }
 
     assert(
-      tr.ran(`fastlane pilot upload --api_key_path ${keyFilePath} -i mypackage.ipa`),
+      tr.ran(`fastlane pilot upload --api_key_path ${keyFilePath} -i mypackage.ipa -j ios`),
       'fastlane pilot upload with api key should have been run.'
     );
     assert(
@@ -342,7 +342,7 @@ describe('app-store-release L0 Suite', function () {
 
     assert(
       tr.ran(
-        `fastlane pilot distribute --api_key_path ${keyFilePath} -a com.microsoft.test.appId --groups Beta`
+        `fastlane pilot distribute --api_key_path ${keyFilePath} -a com.microsoft.test.appId -j ios --groups Beta`
       ),
       'fastlane pilot distribute with api key should have been run.'
     );
@@ -446,7 +446,7 @@ describe('app-store-release L0 Suite', function () {
     await tr.runAsync();
     assert(
       tr.ran(
-        'fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -a com.microsoft.test.appId'
+        'fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -q teamId -a com.microsoft.test.appId'
       ),
       'fastlane pilot upload with teamId should have been run.'
     );
@@ -466,7 +466,7 @@ describe('app-store-release L0 Suite', function () {
 
     await tr.runAsync();
     assert(
-      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -r teamName'),
+      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -r teamName'),
       'fastlane pilot upload with teamName should have been run.'
     );
     assert(
@@ -485,7 +485,7 @@ describe('app-store-release L0 Suite', function () {
 
     await tr.runAsync();
     assert(
-      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -r teamName'),
+      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -q teamId -r teamName'),
       'fastlane pilot upload with teamId and teamName should have been run.'
     );
     assert(
@@ -504,7 +504,7 @@ describe('app-store-release L0 Suite', function () {
 
     await tr.runAsync();
     assert(
-      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa --skip_submission true'),
+      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -j ios --skip_submission true'),
       'fastlane pilot upload with skip_submission should have been run.'
     );
     assert(
@@ -524,7 +524,7 @@ describe('app-store-release L0 Suite', function () {
     await tr.runAsync();
     assert(
       tr.ran(
-        'fastlane pilot upload -u creds-username -i mypackage.ipa --skip_waiting_for_build_processing true'
+        'fastlane pilot upload -u creds-username -i mypackage.ipa -j ios --skip_waiting_for_build_processing true'
       ),
       'fastlane pilot upload with skip_waiting_for_build_processing should have been run.'
     );
@@ -570,7 +570,7 @@ describe('app-store-release L0 Suite', function () {
 
     await tr.runAsync();
     assert(
-      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa'),
+      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -j ios'),
       'fastlane pilot upload with one ip file should have been run.'
     );
     assert(
@@ -619,7 +619,7 @@ describe('app-store-release L0 Suite', function () {
 
     await tr.runAsync();
     assert(
-      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -args someadditioanlargs'),
+      tr.ran('fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -args someadditioanlargs'),
       'fastlane pilot upload with one ip file should have been run.'
     );
     assert(
@@ -638,7 +638,7 @@ describe('app-store-release L0 Suite', function () {
 
     await tr.runAsync();
     assert(
-      tr.ran(`fastlane pilot upload -u creds-username -P mypackage.pkg`),
+      tr.ran(`fastlane pilot upload -u creds-username -P mypackage.pkg -j osx`),
       'fastlane pilot upload with pkg file should have been run.'
     );
   });

--- a/Tasks/AppStoreRelease/Tests/L0ApiKeyEndPoint.ts
+++ b/Tasks/AppStoreRelease/Tests/L0ApiKeyEndPoint.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');
@@ -44,7 +44,7 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
-        "fastlane pilot upload --api_key_path test_temp_path/api_keyD383SF739.json -i mypackage.ipa": {
+        "fastlane pilot upload --api_key_path test_temp_path/api_keyD383SF739.json -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0AppSpecificPassword.ts
+++ b/Tasks/AppStoreRelease/Tests/L0AppSpecificPassword.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');
@@ -44,7 +44,7 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0AppSpecificPasswordEndPoint.ts
+++ b/Tasks/AppStoreRelease/Tests/L0AppSpecificPasswordEndPoint.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');
@@ -41,7 +41,7 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
+++ b/Tasks/AppStoreRelease/Tests/L0AppSpecificPasswordEndPointIncomplete.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');
@@ -41,7 +41,7 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
+++ b/Tasks/AppStoreRelease/Tests/L0AppSpecificPasswordNoFastlaneSession.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');
@@ -43,7 +43,7 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0GemCacheEnvVar.ts
+++ b/Tasks/AppStoreRelease/Tests/L0GemCacheEnvVar.ts
@@ -52,7 +52,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -64,7 +64,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightApiKey.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightApiKey.ts
@@ -55,7 +55,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload --api_key_path test_temp_path/api_keyD383SF739.json -i mypackage.ipa": {
+        "fastlane pilot upload --api_key_path test_temp_path/api_keyD383SF739.json -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -67,7 +67,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightApiKeyDistributeOnly.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightApiKeyDistributeOnly.ts
@@ -58,7 +58,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot distribute --api_key_path test_temp_path/api_keyD383SF739.json -a com.microsoft.test.appId --groups Beta": {
+        "fastlane pilot distribute --api_key_path test_temp_path/api_keyD383SF739.json -a com.microsoft.test.appId -j ios --groups Beta": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -70,7 +70,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightDistributeToExternalTestersWithGroups.ts
@@ -71,7 +71,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa --changelog Release notes for beta release. -a com.microsoft.test.appId --distribute_external true --groups Group1,Group 2": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios --changelog Release notes for beta release. -a com.microsoft.test.appId --distribute_external true --groups Group1,Group 2": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneArguments.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneArguments.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa -args someadditioanlargs": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -args someadditioanlargs": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -66,7 +66,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneMacOS.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightFastlaneMacOS.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');
@@ -27,30 +27,30 @@ process.env['HOME'] = '/usr/bin';
 //tmr.setInput('ipaPath', '<path>');
 
 // provide answers for task mock
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     'which': {
         'ruby': '/usr/bin/ruby',
         'gem': '/usr/bin/gem',
         'deliver': '/usr/bin/deliver',
         'pilot': '/usr/bin/pilot'
     },
-    'checkPath' : {
+    'checkPath': {
         '/usr/bin/ruby': true,
         '/usr/bin/gem': true,
         '/usr/bin/deliver': true,
         '/usr/bin/pilot': true
     },
     'findMatch': {
-      '**/*.pkg': [
-          'mypackage.pkg'
-      ]
+        '**/*.pkg': [
+            'mypackage.pkg'
+        ]
     },
     'exec': {
         '/usr/bin/gem install pilot': {
             'code': 0,
             'stdout': '10 gems installed'
         },
-        'pilot upload -u creds-username -P mypackage.pkg': {
+        'pilot upload -u creds-username -P mypackage.pkg -j osx': {
             'code': 0,
             'stdout': 'consider it uploaded!'
         }

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightNoFastlaneInstall.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightNoFastlaneInstall.ts
@@ -1,7 +1,7 @@
- /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
 'use strict';
 
 import ma = require('azure-pipelines-task-lib/mock-answer');
@@ -42,7 +42,7 @@ let myAnswers: string = `{
         ]
     },
     "exec": {
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightOneIpaFile.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightOneIpaFile.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -65,7 +65,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightServiceEndpoint.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightServiceEndpoint.ts
@@ -14,7 +14,7 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 // replace with mock of setVariable when task-lib has the support
 process.env['ENDPOINT_AUTH_MyServiceEndpoint'] =
-  '{ "parameters": {"username": "creds-username", "password": "creds-password"}, "scheme": "whatever" }';
+    '{ "parameters": {"username": "creds-username", "password": "creds-password"}, "scheme": "whatever" }';
 
 tmr.setInput('authType', 'ServiceEndpoint');
 tmr.setInput('serviceEndpoint', 'MyServiceEndpoint');
@@ -55,7 +55,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -67,7 +67,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightShouldSkipSubmission.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightShouldSkipSubmission.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa --skip_submission true": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios --skip_submission true": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -65,7 +65,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightShouldSkipWaitingForProcessing.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa --skip_waiting_for_build_processing true": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios --skip_waiting_for_build_processing true": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -65,7 +65,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightSpecificFastlaneInstall.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightSpecificFastlaneInstall.ts
@@ -51,7 +51,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -63,7 +63,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightTeamId.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightTeamId.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -a com.microsoft.test.appId": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -q teamId -a com.microsoft.test.appId": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -66,7 +66,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightTeamIdTeamName.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightTeamIdTeamName.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa -q teamId -r teamName": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -q teamId -r teamName": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -66,7 +66,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightTeamName.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightTeamName.ts
@@ -53,7 +53,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa -r teamName": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios -r teamName": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -65,7 +65,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightUserPass.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightUserPass.ts
@@ -51,7 +51,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot upload -u creds-username -i mypackage.ipa": {
+        "fastlane pilot upload -u creds-username -i mypackage.ipa -j ios": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -63,7 +63,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightUserPassDistributeOnly.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightUserPassDistributeOnly.ts
@@ -54,7 +54,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot distribute -u creds-username -a com.microsoft.test.appId --groups Beta": {
+        "fastlane pilot distribute -u creds-username -a com.microsoft.test.appId -j ios --groups Beta": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -66,7 +66,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/Tests/L0TestFlightUserPassDistributeOnlyBuildNumber.ts
+++ b/Tasks/AppStoreRelease/Tests/L0TestFlightUserPassDistributeOnlyBuildNumber.ts
@@ -55,7 +55,7 @@ let myAnswers: string = `{
             "code": 0,
             "stdout": "1 gem installed"
         },
-        "fastlane pilot distribute -u creds-username --build_number 100 -a com.microsoft.test.appId --groups Beta": {
+        "fastlane pilot distribute -u creds-username --build_number 100 -a com.microsoft.test.appId -j ios --groups Beta": {
             "code": 0,
             "stdout": "consider it uploaded!"
         }
@@ -67,7 +67,7 @@ tmr.setAnswers(<ma.TaskLibAnswers>json);
 
 // This is how you can mock NPM packages...
 os.platform = () => {
-  return 'darwin';
+    return 'darwin';
 };
 tmr.registerMock('os', os);
 

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -10,7 +10,9 @@
         "Build",
         "Release"
     ],
-    "demands": [ "xcode" ],
+    "demands": [
+        "xcode"
+    ],
     "version": {
         "Major": "1",
         "Minor": "245",
@@ -178,8 +180,7 @@
                 "tvOS": "tvOS",
                 "macOS": "macOS"
             },
-            "groupName": "releaseOptions",
-            "visibleRule": "distributeOnly = false || releaseTrack = Production"
+            "groupName": "releaseOptions"
         },
         {
             "name": "ipaPath",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -180,8 +180,7 @@
         "tvOS": "tvOS",
         "macOS": "macOS"
       },
-      "groupName": "releaseOptions",
-      "visibleRule": "distributeOnly = false || releaseTrack = Production"
+      "groupName": "releaseOptions"
     },
     {
       "name": "ipaPath",


### PR DESCRIPTION
**Task name**: Fix app type missing on test flight release

**Description**: Add -j args on testflight release

**Documentation changes required:** Y App type required for testflight release

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/app-store-vsts-extension/issues/381

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
