### PR TITLE
Minor package consistency fixes for the App-Store tasks

### DIFF
--- a/Tasks/AppStorePromote/package-lock.json
+++ b/Tasks/AppStorePromote/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^24.10.0",
-        "azure-pipelines-task-lib": "^5.2.6"
+        "azure-pipelines-task-lib": "5.2.8"
       },
       "devDependencies": {
         "typescript": "5.7.2"

--- a/Tasks/AppStorePromote/package-lock.json
+++ b/Tasks/AppStorePromote/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^24.10.0",
+        "@types/node": "24.10.0",
         "azure-pipelines-task-lib": "5.2.8"
       },
       "devDependencies": {
@@ -59,18 +59,18 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.9.tgz",
-      "integrity": "sha1-GutRQuSpKVdInKwSsH+cf+JgV9A=",
+      "version": "24.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha1-a3kIaw38VOd1o0uoEU3MTgIh8x8=",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -152,12 +152,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha1-KrLDj7r/6/iqlf3+bYhDjHoTxSs=",
+      "version": "4.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"

--- a/Tasks/AppStorePromote/package.json
+++ b/Tasks/AppStorePromote/package.json
@@ -5,7 +5,7 @@
   "main": "app-store-promote.js",
   "dependencies": {
     "azure-pipelines-task-lib": "5.2.8",
-    "@types/node": "^24.10.0",
+    "@types/node": "24.10.0",
     "@types/mocha": "^5.2.7"
   },
   "devDependencies": {

--- a/Tasks/AppStorePromote/package.json
+++ b/Tasks/AppStorePromote/package.json
@@ -4,7 +4,7 @@
   "description": "Azure Pipelines task to promote a build in the Apple App Store",
   "main": "app-store-promote.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^5.2.6",
+    "azure-pipelines-task-lib": "5.2.8",
     "@types/node": "^24.10.0",
     "@types/mocha": "^5.2.7"
   },

--- a/Tasks/AppStorePromote/task.json
+++ b/Tasks/AppStorePromote/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "273",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Submit to the App Store for review",

--- a/Tasks/AppStorePromote/task.loc.json
+++ b/Tasks/AppStorePromote/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "273",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AppStoreRelease/package-lock.json
+++ b/Tasks/AppStoreRelease/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^24.10.0",
+        "@types/node": "24.10.0",
         "azure-pipelines-task-lib": "5.2.8"
       },
       "devDependencies": {
@@ -59,18 +59,18 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.8.tgz",
-      "integrity": "sha1-m1KdMuflrbdLE9H8m4NhXpoSpwE=",
+      "version": "24.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha1-a3kIaw38VOd1o0uoEU3MTgIh8x8=",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -152,12 +152,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha1-KrLDj7r/6/iqlf3+bYhDjHoTxSs=",
+      "version": "4.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"

--- a/Tasks/AppStoreRelease/package-lock.json
+++ b/Tasks/AppStoreRelease/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^24.10.0",
-        "azure-pipelines-task-lib": "^5.2.6"
+        "azure-pipelines-task-lib": "5.2.8"
       },
       "devDependencies": {
         "typescript": "5.7.2"

--- a/Tasks/AppStoreRelease/package.json
+++ b/Tasks/AppStoreRelease/package.json
@@ -4,7 +4,7 @@
   "description": "Azure Pipelines task to publish your apps to the Apple App Store",
   "main": "app-store-release.js",
   "dependencies": {
-    "@types/node": "^24.10.0",
+    "@types/node": "24.10.0",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "5.2.8"
   },

--- a/Tasks/AppStoreRelease/package.json
+++ b/Tasks/AppStoreRelease/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@types/node": "^24.10.0",
     "@types/mocha": "^5.2.7",
-    "azure-pipelines-task-lib": "^5.2.6"
+    "azure-pipelines-task-lib": "5.2.8"
   },
   "devDependencies": {
     "typescript": "5.7.2"

--- a/Tasks/AppStoreRelease/task.json
+++ b/Tasks/AppStoreRelease/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "1",
         "Minor": "273",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Publish to the App Store $(releaseTrack) track",

--- a/Tasks/AppStoreRelease/task.loc.json
+++ b/Tasks/AppStoreRelease/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "273",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/IpaResign/package-lock.json
+++ b/Tasks/IpaResign/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^24.10.0",
-        "azure-pipelines-task-lib": "^5.2.6"
+        "azure-pipelines-task-lib": "5.2.8"
       },
       "devDependencies": {
         "typescript": "5.7.2"

--- a/Tasks/IpaResign/package-lock.json
+++ b/Tasks/IpaResign/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^24.10.0",
+        "@types/node": "24.10.0",
         "azure-pipelines-task-lib": "5.2.8"
       },
       "devDependencies": {
@@ -59,18 +59,18 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.9.tgz",
-      "integrity": "sha1-GutRQuSpKVdInKwSsH+cf+JgV9A=",
+      "version": "24.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha1-a3kIaw38VOd1o0uoEU3MTgIh8x8=",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -152,12 +152,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha1-KrLDj7r/6/iqlf3+bYhDjHoTxSs=",
+      "version": "4.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"

--- a/Tasks/IpaResign/package.json
+++ b/Tasks/IpaResign/package.json
@@ -5,7 +5,7 @@
   "main": "ipa-resign.js",
   "dependencies": {
     "azure-pipelines-task-lib": "5.2.8",
-    "@types/node": "^24.10.0",
+    "@types/node": "24.10.0",
     "@types/mocha": "^5.2.7"
   },
   "devDependencies": {

--- a/Tasks/IpaResign/package.json
+++ b/Tasks/IpaResign/package.json
@@ -4,7 +4,7 @@
   "description": "Azure Pipelines task to resign an ipa file",
   "main": "ipa-resign.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^5.2.6",
+    "azure-pipelines-task-lib": "5.2.8",
     "@types/node": "^24.10.0",
     "@types/mocha": "^5.2.7"
   },

--- a/Tasks/IpaResign/task.json
+++ b/Tasks/IpaResign/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": "1",
         "Minor": "273",
-        "Patch": "0"
+        "Patch": "1"
     },
     "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Resign ipa file",

--- a/Tasks/IpaResign/task.loc.json
+++ b/Tasks/IpaResign/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "1",
     "Minor": "273",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/app-store-vsts-extension.json
+++ b/app-store-vsts-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "app-store",
     "name": "Apple App Store",
-    "version": "1.273.0",
+    "version": "1.273.1",
     "publisher": "ms-vsclient",
     "description": "Provides tasks for publishing to Apple's App Store from a TFS/Azure DevOps build or release pipeline",
     "categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.273.0",
+  "version": "1.273.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-store-vsts-extension",
-      "version": "1.273.0",
+      "version": "1.273.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-vsts-extension",
-  "version": "1.273.0",
+  "version": "1.273.1",
   "description": "A set of TFS/Azure Pipelines tasks for publishing apps to the Apple App Store.",
   "main": "make.js",
   "repository": {


### PR DESCRIPTION
**Task name**: AppStorePromote, AppStoreRelease, IpaResign

**Description**: To align with how packages are installed npm install and npm ci to avoid version mismatch when package-lock.json is deleted and created hard fixed the package versions

For example - azure-pipelines-task-lib was resolving to 5.2.8 in the package-lock.json but the package.json was at 5.2.6. Similarly for Node 24.10.x
While this is not an issue since all the pipelines uses npm install and all vulnerabilities are addressed still wanted to make this change before new build / version of task is released.

**Documentation changes required:** (Y/N) No

**Added unit tests:** (Y/N) No test cases were added. Testing done only through CI pipeline

**Attached related issue:** (Y/N) https://github.com/microsoft/app-store-vsts-extension/pull/412
Continuation of the above PR. 
[AB#2361976](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2361976/?view=edit)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
