### PR TITLE
Replace deprecated NodeTool@0 and Npm@0 tasks in build-and-test template

### DIFF
--- a/templates/build-and-test.yml
+++ b/templates/build-and-test.yml
@@ -12,7 +12,7 @@ stages:
     - task: UseNode@1
       displayName: 'Install Node.js'
       inputs:
-        version: '20.19.4'
+        version: '20.x'
 
     - task: NpmAuthenticate@0
       inputs:

--- a/templates/build-and-test.yml
+++ b/templates/build-and-test.yml
@@ -9,15 +9,16 @@ stages:
         targetPath: '$(build.artifactstagingdirectory)'
         artifactName: vsix-unsigned
     steps:
-    - task: NodeTool@0
+    - task: UseNode@1
+      displayName: 'Install Node.js'
       inputs:
-        versionSpec: '20.x'
+        version: '20.19.4'
 
     - task: NpmAuthenticate@0
       inputs:
         workingFile: '.npmrc'
 
-    - task: Npm@0
+    - script: npm install
       displayName: 'npm install'
 
     - script: node make.js build


### PR DESCRIPTION
## Why

A recent pipeline run emitted two deprecation warnings:

> `Task 'Node.js tool installer' version 0 (NodeTool@0) is deprecated. This task is deprecated and will no longer receive updates. Please use UseNodeV1 as a replacement.`

> `The NpmV0 task is scheduled for deprecation in June 2026. Please switch to using NpmAuthenticate and script tasks, or NpmV1.`

Both come from `templates/build-and-test.yml`. This was split out of #423 to keep that PR scoped to the CFS / internal-feed work — there are no network isolation policy or tfx-cli changes here.

## What changed

Only `templates/build-and-test.yml`, 4 insertions / 3 deletions.

**1. `NodeTool@0` → `UseNode@1`**

```diff
-    - task: NodeTool@0
+    - task: UseNode@1
+      displayName: 'Install Node.js'
       inputs:
-        versionSpec: '20.x'
+        version: '20.x'
```

Gotcha worth flagging for reviewers: `UseNode@1` renames the input from `versionSpec` to `version`. Bumping the task name alone while leaving `versionSpec` in place would fail at runtime, so the input key had to change too. The value itself is unchanged — `version` accepts the same semver range syntax, so this keeps installing the latest Node 20 and automatically picks up 20.x patch releases, exactly as before.

Note this intentionally differs from `azure-pipelines.yml`, which pins `UseNode@1` to `20.19.4` in the signing and publishing stages. Build/test staying on a floating spec keeps this PR a pure deprecation fix with no behavior change; pinning it to match would be a separate decision.

**2. `Npm@0` → script step**

```diff
-    - task: Npm@0
+    - script: npm install
       displayName: 'npm install'
```

`NpmAuthenticate@0` is *not* deprecated — it is the recommended replacement path and is left exactly as-is, immediately before the install. `Npm@0` defaulted to the `install` command in the repo root, and a `script:` step runs in `$(System.DefaultWorkingDirectory)`, which is also the repo root, so this is like-for-like.

## CFS / internal-feed routing preserved

This is the important constraint and it is unchanged:

- The `NpmAuthenticate@0` → install ordering is intact; the script step still runs after authentication.
- The script step picks up the root `.npmrc`, which points at `pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/`.
- No `--registry` flag or any other redirect to public npmjs was added.

Verified locally that `npm config get registry` resolves to the internal feed and that `npm install` completes against it.

## Validation

- `templates/build-and-test.yml` parses as valid YAML; the step list is structurally intact at 8 steps in the original order (`UseNode@1` → `NpmAuthenticate@0` → `npm install` → build → test → createtest → create → `CopyFiles@2`).
- `UseNode@1` input key confirmed as `version`, matching existing usage in `azure-pipelines.yml`.
- `npm install` — passes (resolved through the internal feed).
- `node make.js build` — passes, "Build successful".
- `node make.js test` — passes, mocha suites green across the Node versions the harness exercises.

`azure-pipelines.yml` and `pr-check.yml` are untouched.

## Follow-up suggestion (not done here)

The repo has a `package-lock.json`, so `npm ci` would give stricter, faster, fully lockfile-driven installs. I deliberately kept `npm install` to make this a pure deprecation fix with no behavior change — raising `npm ci` as a separate follow-up rather than bundling it in.